### PR TITLE
misc fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aserto-dev/errors v0.0.2
 	github.com/aserto-dev/go-authorizer v0.20.1
 	github.com/aserto-dev/go-directory v0.20.1
-	github.com/aserto-dev/go-directory-cli v0.20.7
+	github.com/aserto-dev/go-directory-cli v0.20.8
 	github.com/aserto-dev/go-edge-ds v0.20.2
 	github.com/aserto-dev/go-http-metrics v0.10.1-20221024-1
 	github.com/aserto-dev/logger v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/aserto-dev/go-authorizer v0.20.1 h1:01ry1AmhOhhGVeWyyvTVTnoCG6lYjmY5u
 github.com/aserto-dev/go-authorizer v0.20.1/go.mod h1:RTpBixDT2WIPOkXcewCXG3NxOWDt22yiXMb+qvdxucM=
 github.com/aserto-dev/go-directory v0.20.1 h1:tOoZPUeNqtiuy/kd/24oju0aTTug2tt6dx4qnLFxbJA=
 github.com/aserto-dev/go-directory v0.20.1/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
-github.com/aserto-dev/go-directory-cli v0.20.7 h1:QfyqPP0XlpQ9zFEkhW98bkypPTpMftKlLvFXza+6XLg=
-github.com/aserto-dev/go-directory-cli v0.20.7/go.mod h1:mBef3fu/mrWCpoKMB8BU1BLwhqHMF52ypEzObR5qj2Q=
+github.com/aserto-dev/go-directory-cli v0.20.8 h1:Ko4c5CR1EoiUo3IaAIZ1HBbOdzeTTFMcYejtl8LuOeI=
+github.com/aserto-dev/go-directory-cli v0.20.8/go.mod h1:mBef3fu/mrWCpoKMB8BU1BLwhqHMF52ypEzObR5qj2Q=
 github.com/aserto-dev/go-edge-ds v0.20.2 h1:ZtVB3KK2FtutcXdvW9nNi4zgxdBztPGdS6LKMOEUhHs=
 github.com/aserto-dev/go-edge-ds v0.20.2/go.mod h1:AFn7Tt4ShTV+RDPPGGB3LLtUZwB5MVR8IPCFxXYj4+k=
 github.com/aserto-dev/go-grpc v0.8.0/go.mod h1:hog+zu5jE3+Y6t7m5PIBlavosmbd2qdF0BGZ9ueWK74=

--- a/pkg/cc/config/config.go
+++ b/pkg/cc/config/config.go
@@ -22,7 +22,7 @@ import (
 type CommandMode int
 
 var (
-	DefaultTLSGenDir = os.ExpandEnv("$HOME/.config/aserto/authorizer/certs")
+	DefaultTLSGenDir = os.ExpandEnv("$HOME/.config/topaz/certs")
 	CertificateSets  = []string{"grpc", "gateway"}
 )
 

--- a/pkg/cli/cmd/configure.go
+++ b/pkg/cli/cmd/configure.go
@@ -26,6 +26,14 @@ func (cmd ConfigureCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
+	if _, err := CreateCertsDir(); err != nil {
+		return err
+	}
+
+	if _, err := CreateDataDir(); err != nil {
+		return err
+	}
+
 	params := templateParams{
 		PolicyName:    cmd.PolicyName,
 		Resource:      cmd.Resource,
@@ -61,6 +69,34 @@ func CreateConfigDir() (string, error) {
 	}
 
 	return configDir, os.MkdirAll(configDir, 0700)
+}
+
+func CreateCertsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	certsDir := path.Join(home, "/.config/topaz/certs")
+	if fi, err := os.Stat(certsDir); err == nil && fi.IsDir() {
+		return certsDir, nil
+	}
+
+	return certsDir, os.MkdirAll(certsDir, 0700)
+}
+
+func CreateDataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	dataDir := path.Join(home, "/.config/topaz/db")
+	if fi, err := os.Stat(dataDir); err == nil && fi.IsDir() {
+		return dataDir, nil
+	}
+
+	return dataDir, os.MkdirAll(dataDir, 0700)
 }
 
 func WriteConfig(w io.Writer, templ string, params *templateParams) error {

--- a/pkg/cli/cmd/load.go
+++ b/pkg/cli/cmd/load.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aserto-dev/topaz/pkg/cli/clients"
 	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
 	"github.com/fatih/color"
+	"github.com/google/uuid"
 )
 
 type LoadCmd struct {
@@ -26,6 +27,7 @@ func (cmd *LoadCmd) Run(c *cc.CommonCtx) error {
 		return nil
 	}
 
+	cmd.Config.SessionID = uuid.NewString()
 	dirClient, err := clients.NewDirectoryClient(c, &cmd.Config)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/start.go
+++ b/pkg/cli/cmd/start.go
@@ -100,11 +100,11 @@ func (cmd *StartCmd) dockerArgs() []string {
 	return append(args, containerName...)
 }
 
-func (cmd *StartCmd) env(path string) map[string]string {
+func (cmd *StartCmd) env(rootPath string) map[string]string {
 	return map[string]string{
-		"TOPAZ_CERTS_DIR":    path,
-		"TOPAZ_CFG_DIR":      path,
-		"TOPAZ_EDS_DIR":      path,
+		"TOPAZ_CERTS_DIR":    rootPath,
+		"TOPAZ_CFG_DIR":      rootPath,
+		"TOPAZ_EDS_DIR":      rootPath,
 		"CONTAINER_NAME":     cmd.ContainerName,
 		"CONTAINER_VERSION":  cmd.ContainerVersion,
 		"CONTAINER_HOSTNAME": cmd.Hostname,


### PR DESCRIPTION
Misc fixes:

* Update DefaultTLSGenDir to "$HOME/.config/topaz/certs"
* Configure to validate the existence of $HOME/.config/topaz/certs and $HOME/.config/topaz/db, create when not present to, satisfy container volume mount
* Set session_id for Load (manifest) to handle "hash value mismatch" error
* Start to validate "$HOME/.config/topaz/cfg/config.yaml" existence on start
* Start to validate the existence of $HOME/.config/topaz/certs and $HOME/.config/topaz/db, create when not present to satisfy container volume mount

