### PR TITLE
Allow users to be resolved by ID

### DIFF
--- a/directory/identity.go
+++ b/directory/identity.go
@@ -2,20 +2,19 @@ package directory
 
 import (
 	"context"
+	"errors"
 
+	cerr "github.com/aserto-dev/errors"
 	"github.com/aserto-dev/go-authorizer/pkg/aerr"
 	v2 "github.com/aserto-dev/go-directory/aserto/directory/common/v2"
 	ds2 "github.com/aserto-dev/go-directory/aserto/directory/reader/v2"
-	"github.com/google/uuid"
+	"github.com/aserto-dev/go-directory/pkg/derr"
 )
 
 func GetIdentityV2(client ds2.ReaderClient, ctx context.Context, identity string) (*v2.Object, error) {
 	identityString := "identity"
 	obj := v2.ObjectIdentifier{Type: &identityString, Key: &identity}
-	_, err := uuid.Parse(identity)
-	if err == nil {
-		obj = v2.ObjectIdentifier{Id: &identity}
-	}
+
 	relationString := "identifier"
 	subjectType := "user"
 	withObjects := true
@@ -28,15 +27,16 @@ func GetIdentityV2(client ds2.ReaderClient, ctx context.Context, identity string
 		},
 		WithObjects: &withObjects,
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	if relResp.Results == nil {
+	switch {
+	case err != nil && errors.Is(cerr.UnwrapAsertoError(err), derr.ErrNotFound):
 		return nil, aerr.ErrDirectoryObjectNotFound
-	}
+	case err != nil:
+		return nil, err
 
-	if len(relResp.Objects) == 0 {
+	case relResp.Results == nil:
+		return nil, aerr.ErrDirectoryObjectNotFound
+
+	case len(relResp.Objects) == 0:
 		return nil, aerr.ErrDirectoryObjectNotFound.Msg("no objects found in relation")
 	}
 

--- a/pkg/app/impl/jwt.go
+++ b/pkg/app/impl/jwt.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aserto-dev/go-authorizer/aserto/authorizer/v2/api"
 	"github.com/aserto-dev/go-authorizer/pkg/aerr"
 	v2 "github.com/aserto-dev/go-directory/aserto/directory/common/v2"
+	ds2 "github.com/aserto-dev/go-directory/aserto/directory/reader/v2"
 	"github.com/aserto-dev/topaz/builtins/edge/ds"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jwt"
@@ -187,5 +188,25 @@ func (s *AuthorizerServer) getUserFromIdentity(ctx context.Context, identity str
 	default:
 	}
 
+	if user == nil {
+		return s.getObject(ctx, identity)
+	}
+
 	return user, nil
+}
+
+func (s *AuthorizerServer) getObject(ctx context.Context, id string) (proto.Message, error) {
+	client, err := s.resolver.GetDirectoryResolver().GetDS(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	objResp, err := client.GetObject(ctx, &ds2.GetObjectRequest{
+		Param: &v2.ObjectIdentifier{Id: &id},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return objResp.Result, nil
 }


### PR DESCRIPTION
If an incoming `IdentityContext` contains a user ID as the identity, we should still be able to resolve the user.
This PR fixes a regression introduced in #35 that caused this behavior to stop working.

If the call to `GetRelation` returns `ErrNotFound` and the identity value is a valid UUID, we should attempt to treat it as a user ID and call `GetObject`.