### PR TITLE
fix topaz install regression

### DIFF
--- a/pkg/cli/cmd/install.go
+++ b/pkg/cli/cmd/install.go
@@ -12,8 +12,9 @@ type InstallCmd struct {
 }
 
 func (cmd InstallCmd) Run(c *cc.CommonCtx) error {
-	if err := CheckRunning(c); err != nil {
-		return err
+	if err := CheckRunning(c); err == nil {
+		color.Yellow("!!! topaz is already running")
+		return nil
 	}
 
 	color.Green(">>> installing topaz...")


### PR DESCRIPTION
Fix `topaz install` regression

Before `topaz install` would fails with 

❯ topaz install
topaz: error: topaz is not running, use 'topaz start' or 'topaz run' to start

Which prevents installing topaz, unless when the `--no-check` flag was passed as a work-around.

This PR fixes this behavior.
