### PR TITLE
add support for env variable in config

### DIFF
--- a/pkg/cli/cmd/run.go
+++ b/pkg/cli/cmd/run.go
@@ -8,9 +8,10 @@ import (
 )
 
 type RunCmd struct {
-	ContainerName    string `optional:"" default:"topaz" help:"container name"`
-	ContainerVersion string `optional:"" default:"latest" help:"container version" `
-	Hostname         string `optional:"" help:"hostname for docker to set"`
+	ContainerName    string   `optional:"" default:"topaz" help:"container name"`
+	ContainerVersion string   `optional:"" default:"latest" help:"container version" `
+	Hostname         string   `optional:"" help:"hostname for docker to set"`
+	Env              []string `optional:"" short:"e" help:"additional environment variable names to be passed to container"`
 }
 
 func (cmd *RunCmd) Run(c *cc.CommonCtx) error {
@@ -46,6 +47,10 @@ func (cmd *RunCmd) dockerArgs() []string {
 	args := append([]string{}, dockerCmd...)
 	args = append(args, "-ti")
 	args = append(args, dockerArgs...)
+
+	for _, env := range cmd.Env {
+		args = append(args, "--env", env)
+	}
 
 	if cmd.Hostname != "" {
 		args = append(args, hostname...)

--- a/pkg/cli/cmd/start.go
+++ b/pkg/cli/cmd/start.go
@@ -12,9 +12,10 @@ import (
 )
 
 type StartCmd struct {
-	ContainerName    string `optional:"" default:"topaz" help:"container name"`
-	ContainerVersion string `optional:"" default:"latest" help:"container version" `
-	Hostname         string `optional:"" help:"hostname for docker to set"`
+	ContainerName    string   `optional:"" default:"topaz" help:"container name"`
+	ContainerVersion string   `optional:"" default:"latest" help:"container version" `
+	Hostname         string   `optional:"" help:"hostname for docker to set"`
+	Env              []string `optional:"" short:"e" help:"additional environment variable names to be passed to container"`
 }
 
 func (cmd *StartCmd) Run(c *cc.CommonCtx) error {
@@ -97,6 +98,10 @@ func (cmd *StartCmd) dockerArgs() []string {
 	args := append([]string{}, dockerCmd...)
 	args = append(args, dockerArgs...)
 	args = append(args, daemonArgs...)
+
+	for _, env := range cmd.Env {
+		args = append(args, "--env", env)
+	}
 
 	if cmd.Hostname != "" {
 		args = append(args, hostname...)


### PR DESCRIPTION
This PR adds support for using environment variable in the topaz config file like this:

```
opa:
  instance_id: "-"
  graceful_shutdown_period_seconds: 2
  local_bundles:
    paths: []
    skip_verification: true
  config:
    services:
      ghcr:
        url: https://ghcr.io/
        type: "oci"
        response_header_timeout_seconds: 5
        credentials:
          bearer:
            token: "${GIT_TOKEN}"
            scheme: "basic"
    bundles:
      demo:
        service: ghcr
        resource: "ghcr.io/gertd/policy-test-private:0.0.2"
        persist: true
        config:
          polling:
            min_delay_seconds: 60
            max_delay_seconds: 120

```

To use with `topaz start`

```
topaz start --env GIT_TOKEN --env GIT_USER
```

To use with `topaz run`

```
topaz run --env GIT_TOKEN --env GIT_USER
```