### PR TITLE
Fix panic in `Is` when missng Aserto-Tenant-Id header

### DIFF
--- a/pkg/app/impl/authz.go
+++ b/pkg/app/impl/authz.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aserto-dev/go-authorizer/aserto/authorizer/v2"
 	"github.com/aserto-dev/go-authorizer/aserto/authorizer/v2/api"
 	"github.com/aserto-dev/go-authorizer/pkg/aerr"
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 
 	runtime "github.com/aserto-dev/runtime"
 	decisionlog_plugin "github.com/aserto-dev/topaz/decision_log/plugin"
@@ -316,11 +317,12 @@ func (s *AuthorizerServer) Is(ctx context.Context, req *authorizer.IsRequest) (*
 }
 
 func getTenantID(ctx context.Context) *string {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if ok {
-		id := md.Get("Aserto-Tenant-Id")[0]
-		return &id
+	md := metautils.ExtractIncoming(ctx)
+	tenantID := md.Get("Aserto-Tenant-Id")
+	if tenantID != "" {
+		return &tenantID
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
When calling `Is` without passing an aserto-tenant-id header, the authorizer panics:
```
panic: runtime error: index out of range [0] with length 0

goroutine 117 [running]:
github.com/aserto-dev/topaz/pkg/app/impl.getTenantID({0x140b468?, 0xc0004c9d70?})
	/src/pkg/app/impl/authz.go:321 +0xb9
github.com/aserto-dev/topaz/pkg/app/impl.(*AuthorizerServer).Is(0xc000010ae0, {0x140b468, 0xc0004c9d70}, 0xc000395770)
	/src/pkg/app/impl/authz.go:287 +0xf7c
github.com/aserto-dev/go-authorizer/aserto/authorizer/v2._Authorizer_Is_Handler({0x11bab60?, 0xc000010ae0}, {0x140b468, 0xc0004c9d70}, 0xc00031b8f0, 0x0)
	/go/pkg/mod/github.com/aserto-dev/go-authorizer@v0.20.2/aserto/authorizer/v2/authorizer_grpc.pb.go:179 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001b94a0, {0x14112a0, 0xc00046d040}, 0xc000315440, 0xc0004b9230, 0x1c51db8, 0xc000448e80)
	/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1340 +0xd23
google.golang.org/grpc.(*Server).handleStream(0xc0001b94a0, {0x14112a0, 0xc00046d040}, 0xc000315440, 0xc000448e80)
	/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1713 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:965 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:963 +0x28a
```

The `Aserto-Tenant-Id` header is supposed to be optional. It's only used in decision logging to augment the log message with a tenant ID.
