### PR TITLE
Support running local bundles

### DIFF
--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
@@ -9,8 +8,6 @@ import (
 	"github.com/aserto-dev/topaz/pkg/cli/x"
 	"github.com/aserto-dev/topaz/pkg/version"
 )
-
-var ErrNotRunning = errors.New("topaz is not running, use 'topaz start' or 'topaz run' to start")
 
 type CLI struct {
 	Backup    BackupCmd    `cmd:"" help:"backup directory data"`
@@ -49,7 +46,7 @@ func CheckRunning(c *cc.CommonCtx) error {
 
 	if running, err := dockerx.IsRunning(dockerx.Topaz); !running || err != nil {
 		if !running {
-			return ErrNotRunning
+			return dockerx.ErrNotRunning
 		}
 		if err != nil {
 			return err

--- a/pkg/cli/cmd/configure.go
+++ b/pkg/cli/cmd/configure.go
@@ -11,8 +11,8 @@ import (
 )
 
 type ConfigureCmd struct {
-	PolicyName    string `arg:"" required:"" help:"policy name"`
-	Resource      string `short:"r" required:"" help:"resource url"`
+	PolicyName    string `arg:"" required:"" help:"policy name or '-' for running a local policy bundle"`
+	Resource      string `short:"r" required:"" help:"resource url or local policy bundle path"`
 	Stdout        bool   `short:"p" help:"generated configuration is printed to stdout but not saved"`
 	EdgeDirectory bool   `short:"d" help:"enable edge directory" default:"false"`
 	SeedMetadata  bool   `short:"s" help:"enable seed metadata" default:"false"`

--- a/pkg/cli/cmd/run.go
+++ b/pkg/cli/cmd/run.go
@@ -3,69 +3,15 @@ package cmd
 import (
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
-
-	"github.com/fatih/color"
 )
 
 type RunCmd struct {
-	ContainerName    string   `optional:"" default:"topaz" help:"container name"`
-	ContainerVersion string   `optional:"" default:"latest" help:"container version" `
-	Hostname         string   `optional:"" help:"hostname for docker to set"`
-	Env              []string `optional:"" short:"e" help:"additional environment variable names to be passed to container"`
+	*dockerx.Container `embed:""`
 }
 
 func (cmd *RunCmd) Run(c *cc.CommonCtx) error {
-	if running, err := dockerx.IsRunning(dockerx.Topaz); running || err != nil {
-		if !running {
-			return ErrNotRunning
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	color.Green(">>> starting topaz...")
-
-	args := cmd.dockerArgs()
-
-	cmdArgs := []string{
-		"run",
-		"--config-file", "/config/config.yaml",
-	}
-
-	args = append(args, cmdArgs...)
-
-	path, err := dockerx.DefaultRoots()
-	if err != nil {
+	if err := createMountDirs(); err != nil {
 		return err
 	}
-
-	return dockerx.DockerWith(cmd.env(path), args...)
-}
-
-func (cmd *RunCmd) dockerArgs() []string {
-	args := append([]string{}, dockerCmd...)
-	args = append(args, "-ti")
-	args = append(args, dockerArgs...)
-
-	for _, env := range cmd.Env {
-		args = append(args, "--env", env)
-	}
-
-	if cmd.Hostname != "" {
-		args = append(args, hostname...)
-	}
-
-	return append(args, containerName...)
-}
-
-func (cmd *RunCmd) env(path string) map[string]string {
-	return map[string]string{
-		"TOPAZ_CERTS_DIR":    path,
-		"TOPAZ_CFG_DIR":      path,
-		"TOPAZ_EDS_DIR":      path,
-		"CONTAINER_NAME":     cmd.ContainerName,
-		"CONTAINER_VERSION":  cmd.ContainerVersion,
-		"CONTAINER_HOSTNAME": cmd.Hostname,
-	}
+	return cmd.Start(dockerx.Interactive)
 }

--- a/pkg/cli/cmd/start.go
+++ b/pkg/cli/cmd/start.go
@@ -1,53 +1,22 @@
 package cmd
 
 import (
-	"os"
-	"path"
-
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
-	"github.com/pkg/errors"
-
-	"github.com/fatih/color"
 )
 
 type StartCmd struct {
-	ContainerName    string   `optional:"" default:"topaz" help:"container name"`
-	ContainerVersion string   `optional:"" default:"latest" help:"container version" `
-	Hostname         string   `optional:"" help:"hostname for docker to set"`
-	Env              []string `optional:"" short:"e" help:"additional environment variable names to be passed to container"`
+	*dockerx.Container `embed:""`
 }
 
 func (cmd *StartCmd) Run(c *cc.CommonCtx) error {
-	if running, err := dockerx.IsRunning(dockerx.Topaz); running || err != nil {
-		if !running {
-			return ErrNotRunning
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	color.Green(">>> starting topaz...")
-
-	args := cmd.dockerArgs()
-
-	cmdArgs := []string{
-		"run",
-		"--config-file", "/config/config.yaml",
-	}
-
-	args = append(args, cmdArgs...)
-
-	rootPath, err := dockerx.DefaultRoots()
-	if err != nil {
+	if err := createMountDirs(); err != nil {
 		return err
 	}
+	return cmd.Start(dockerx.Deamon)
+}
 
-	if _, err := os.Stat(path.Join(rootPath, "cfg", "config.yaml")); errors.Is(err, os.ErrNotExist) {
-		return errors.Errorf("%s does not exist, please run 'topaz configure'", path.Join(rootPath, "cfg", "config.yaml"))
-	}
-
+func createMountDirs() error {
 	if _, err := CreateCertsDir(); err != nil {
 		return err
 	}
@@ -56,67 +25,5 @@ func (cmd *StartCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
-	return dockerx.DockerWith(cmd.env(rootPath), args...)
-}
-
-var (
-	dockerCmd = []string{
-		"run",
-	}
-
-	dockerArgs = []string{
-		"--rm",
-		"--name", dockerx.Topaz,
-		"--platform=linux/amd64",
-		"-p", "8282:8282",
-		"-p", "8383:8383",
-		"-p", "8484:8484",
-		"-p", "9292:9292",
-		"-v", "$TOPAZ_CERTS_DIR/certs:/certs:rw",
-		"-v", "$TOPAZ_CFG_DIR/cfg:/config:ro",
-		"-v", "$TOPAZ_EDS_DIR/db:/db:rw",
-	}
-
-	daemonArgs = []string{
-		"-d",
-	}
-
-	containerName = []string{
-		"ghcr.io/aserto-dev/$CONTAINER_NAME:$CONTAINER_VERSION",
-	}
-
-	hostname = []string{
-		"--hostname", "$CONTAINER_HOSTNAME",
-	}
-
-	platform = []string{
-		"--platform", "linux/amd64",
-	}
-)
-
-func (cmd *StartCmd) dockerArgs() []string {
-	args := append([]string{}, dockerCmd...)
-	args = append(args, dockerArgs...)
-	args = append(args, daemonArgs...)
-
-	for _, env := range cmd.Env {
-		args = append(args, "--env", env)
-	}
-
-	if cmd.Hostname != "" {
-		args = append(args, hostname...)
-	}
-
-	return append(args, containerName...)
-}
-
-func (cmd *StartCmd) env(rootPath string) map[string]string {
-	return map[string]string{
-		"TOPAZ_CERTS_DIR":    rootPath,
-		"TOPAZ_CFG_DIR":      rootPath,
-		"TOPAZ_EDS_DIR":      rootPath,
-		"CONTAINER_NAME":     cmd.ContainerName,
-		"CONTAINER_VERSION":  cmd.ContainerVersion,
-		"CONTAINER_HOSTNAME": cmd.Hostname,
-	}
+	return nil
 }

--- a/pkg/cli/cmd/templates.go
+++ b/pkg/cli/cmd/templates.go
@@ -13,8 +13,12 @@ opa:
   instance_id: "-"
   graceful_shutdown_period_seconds: 2
   local_bundles:
-    paths: []
     skip_verification: true
+{{- if eq .PolicyName "-" }}
+    paths:
+    - {{ .Resource }}
+{{ else }}
+    paths: []
   config:
     services:
       ghcr:
@@ -30,11 +34,12 @@ opa:
           polling:
             min_delay_seconds: 60
             max_delay_seconds: 120
+{{ end }}
 `
 
 const templatePreamble = `---
 logging:
-  prod: true
+  prod: false
   log_level: info
 
 directory_service:

--- a/pkg/cli/cmd/update.go
+++ b/pkg/cli/cmd/update.go
@@ -17,11 +17,11 @@ func (cmd UpdateCmd) Run(c *cc.CommonCtx) error {
 
 	args := []string{}
 	args = append(args, "pull")
-	args = append(args, platform...)
+	args = append(args, dockerx.Platform...)
 	if cmd.Hostname != "" {
-		args = append(args, hostname...)
+		args = append(args, dockerx.Hostname...)
 	}
-	args = append(args, containerName...)
+	args = append(args, dockerx.ImageName...)
 
 	return dockerx.DockerWith(map[string]string{
 		"CONTAINER_NAME":    cmd.ContainerName,

--- a/pkg/cli/dockerx/container.go
+++ b/pkg/cli/dockerx/container.go
@@ -1,0 +1,169 @@
+package dockerx
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+var ErrNotRunning = errors.New("topaz is not running, use 'topaz start' or 'topaz run' to start")
+
+type RunMode bool
+
+const (
+	Interactive RunMode = true
+	Deamon      RunMode = false
+)
+
+type Container struct {
+	ContainerName    string   `optional:"" default:"topaz" help:"container name"`
+	ContainerVersion string   `optional:"" default:"latest" help:"container version" `
+	Hostname         string   `optional:"" help:"hostname for docker to set"`
+	Env              []string `optional:"" short:"e" help:"additional environment variable names to be passed to container"`
+}
+
+func (c *Container) env(rootPath string) map[string]string {
+	return map[string]string{
+		"TOPAZ_CERTS_DIR":    rootPath,
+		"TOPAZ_CFG_DIR":      rootPath,
+		"TOPAZ_EDS_DIR":      rootPath,
+		"CONTAINER_NAME":     c.ContainerName,
+		"CONTAINER_VERSION":  c.ContainerVersion,
+		"CONTAINER_HOSTNAME": c.Hostname,
+	}
+}
+
+func (c *Container) dockerArgs(localBundles []string, mode RunMode) []string {
+	args := append([]string{}, dockerCmd...)
+	args = append(args, dockerArgs...)
+	switch mode {
+	case Interactive:
+		args = append(args, "-ti")
+	case Deamon:
+		args = append(args, "-d")
+	}
+
+	args = append(args, localBundleMounts(localBundles)...)
+
+	for _, env := range c.Env {
+		args = append(args, "--env", env)
+	}
+
+	if c.Hostname != "" {
+		args = append(args, Hostname...)
+	}
+
+	return append(args, ImageName...)
+}
+
+func (c *Container) Start(mode RunMode) error {
+	if running, err := IsRunning(Topaz); running || err != nil {
+		if !running {
+			return ErrNotRunning
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	rootPath, err := DefaultRoots()
+	if err != nil {
+		return err
+	}
+
+	configFile := path.Join(rootPath, "cfg", "config.yaml")
+	localBundles, err := parseLocalBundles(configFile)
+	if err != nil {
+		return err
+	}
+
+	color.Green(">>> starting topaz...")
+
+	args := c.dockerArgs(localBundles, mode)
+
+	cmdArgs := []string{
+		"run",
+		"--config-file", "/config/config.yaml",
+	}
+
+	args = append(args, cmdArgs...)
+
+	return DockerWith(c.env(rootPath), args...)
+
+}
+
+var (
+	dockerCmd = []string{
+		"run",
+	}
+
+	dockerArgs = []string{
+		"--rm",
+		"--name", Topaz,
+		"--platform=linux/amd64",
+		"-p", "8282:8282",
+		"-p", "8383:8383",
+		"-p", "8484:8484",
+		"-p", "9292:9292",
+		"-v", "$TOPAZ_CERTS_DIR/certs:/certs:rw",
+		"-v", "$TOPAZ_CFG_DIR/cfg/config.yaml:/config/config.yaml:ro",
+		"-v", "$TOPAZ_EDS_DIR/db:/db:rw",
+	}
+
+	ImageName = []string{
+		"ghcr.io/aserto-dev/$CONTAINER_NAME:$CONTAINER_VERSION",
+	}
+
+	Hostname = []string{
+		"--hostname", "$CONTAINER_HOSTNAME",
+	}
+
+	Platform = []string{
+		"--platform", "linux/amd64",
+	}
+)
+
+type topazConfig struct {
+	OPA struct {
+		LocalBundles struct {
+			Paths []string `yaml:"paths"`
+		} `yaml:"local_bundles"`
+	} `yaml:"opa"`
+}
+
+func parseLocalBundles(configFile string) ([]string, error) {
+	bundles := []string{}
+
+	f, err := os.Open(configFile)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return bundles, errors.Errorf("%s does not exist, please run 'topaz configure'", configFile)
+	case err != nil:
+		return bundles, errors.Wrapf(err, "failed to open %s", configFile)
+	}
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return bundles, errors.Wrapf(err, "failed to read %s", configFile)
+	}
+
+	var cfg topazConfig
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return bundles, errors.Wrapf(err, "failed to parse %s", configFile)
+	}
+
+	return cfg.OPA.LocalBundles.Paths, nil
+}
+
+func localBundleMounts(localBundles []string) []string {
+	mounts := []string{}
+	for _, bundle := range localBundles {
+		mounts = append(mounts, "-v", fmt.Sprintf("%s:%s:ro", bundle, bundle))
+	}
+	return mounts
+}


### PR DESCRIPTION
This commit adds the ability to configure topaz to run a local policy bundle.

If the policy name passed to `topaz configure` is `"-"` (dash) then the resource argument is interpreted as a path in the local filesystem.

Example:
```sh
topaz configure - -r ~/policies/policy-todo/src
```

When starting the authorizer using `topaz start` or `topaz run`, the path specified in config under `opa.local_bundles.paths` is mounted into the topaz container using the same path as the host filesystem.
If more then one path is specified, an error is returned.