### PR TITLE
fix ds.relation({}) does not return template

### DIFF
--- a/builtins/edge/ds/relation.go
+++ b/builtins/edge/ds/relation.go
@@ -51,7 +51,7 @@ func RegisterRelation(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 				return nil, err
 			}
 
-			if a == nil {
+			if a == nil || a.RelationIdentifier == nil {
 
 				a = &extendedRelation{
 					RelationIdentifier: &dsc.RelationIdentifier{

--- a/builtins/edge/ds/relation.go
+++ b/builtins/edge/ds/relation.go
@@ -32,8 +32,9 @@ import (
 //		  "id": "",
 //		  "key": "",
 //		  "type": ""
-//		}
-//	})
+//		},
+//		"with_objects": false
+//	  })
 type extendedRelation struct {
 	*dsc.RelationIdentifier
 	WithObjects bool `json:"with_objects"`


### PR DESCRIPTION
Fix regression of ds.relation built-in no longer returning the template structure when passiong in a null object

