### PR TITLE
make topaz config root directory overrideable

### DIFF
--- a/pkg/cli/cmd/templates.go
+++ b/pkg/cli/cmd/templates.go
@@ -39,7 +39,7 @@ logging:
 
 directory_service:
   edge:
-    db_path: /db/directory.db
+    db_path: ${TOPAZ_DIR}/db/directory.db
     seed_metadata: {{ .SeedMetadata }}
     {{if .EdgeDirectory}}
   remote:
@@ -51,18 +51,18 @@ api:
     connection_timeout_seconds: 2
     listen_address: "0.0.0.0:8282"
     certs:
-      tls_key_path: "/certs/grpc.key"
-      tls_cert_path: "/certs/grpc.crt"
-      tls_ca_cert_path: "/certs/grpc-ca.crt"
+      tls_key_path: "${TOPAZ_DIR}/certs/grpc.key"
+      tls_cert_path: "${TOPAZ_DIR}/certs/grpc.crt"
+      tls_ca_cert_path: "${TOPAZ_DIR}/certs/grpc-ca.crt"
   gateway:
     listen_address: "0.0.0.0:8383"
     allowed_origins:
     - https://*.aserto.com
     - https://*aserto-console.netlify.app
     certs:
-      tls_key_path: "/certs/gateway.key"
-      tls_cert_path: "/certs/gateway.crt"
-      tls_ca_cert_path: "/certs/gateway-ca.crt"
+      tls_key_path: "${TOPAZ_DIR}/certs/gateway.key"
+      tls_cert_path: "${TOPAZ_DIR}/certs/gateway.crt"
+      tls_ca_cert_path: "${TOPAZ_DIR}/certs/gateway-ca.crt"
   health:
     listen_address: "0.0.0.0:8484"
 `


### PR DESCRIPTION
Currently the config.yaml file generated by the topaz CLI configure command is hardwired to $HOME/.config/topaz/[certs|cfg|db]

This change makes the root configurable via the TOPAZ_DIR environment variable

Resulting in the following location paths:
```
certs: ${TOPAZ_DIR}/certs
cfg: ${TOPAZ_DIR?/cfg
db: ${TOPAZ_DIR}/db
```

This change is backwards compatible with the current location, as the topaz config.subEnvVars() function will remove the ${TROPAZ_DIR} when no value is provided.

This change was made to facility isolating config_data instances 



