### PR TITLE
use logger.Config

### DIFF
--- a/pkg/cc/config/config.go
+++ b/pkg/cc/config/config.go
@@ -38,11 +38,7 @@ const (
 
 // Config holds the configuration for the app.
 type Common struct {
-	Logging struct {
-		Prod           bool          `json:"prod"`
-		LogLevel       string        `json:"log_level"`
-		LogLevelParsed zerolog.Level `json:"-"`
-	} `json:"logging"`
+	Logging logger.Config `json:"logging"`
 
 	Command struct {
 		Mode CommandMode


### PR DESCRIPTION
This PR changes the internal Logging struct defintion to use the logging package one, in order to add the grp_log_level additions and to centrallize struct definition

Was:
```
type Common struct {
	Logging struct {
		Prod           bool          `json:"prod"`
		LogLevel       string        `json:"log_level"`
		LogLevelParsed zerolog.Level `json:"-"`
	} `json:"logging"`
  
	Command struct {
	// !!rest removed for clarity as it is unchanged!!
}
```
Will be:
```
type Common struct {
	Logging logger.Config `json:"logging"`

	Command struct {
	// !!rest removed for clarity as it is unchanged!!
}
```
