### PR TITLE
added insecure flag for topaz import

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ curl https://raw.githubusercontent.com/aserto-dev/topaz/main/assets/citadel-rela
 Import the contents of the file into Topaz directory. This creates the sample users (Rick, Morty, and friends); groups; and relations.
 
 ```shell
-topaz import -d .
+topaz import -i -d .
 ```
 
 ### Issue an API call


### PR DESCRIPTION
Topaz needs the insecure flag to execute this command against a local directory.

This matches the README quickstart to the topaz docs. 