### PR TITLE
[DO NOT MERGE] Remote directory 0.21 (disable edge-ds)

### DIFF
--- a/builtins/edge/ds/check.go
+++ b/builtins/edge/ds/check.go
@@ -16,7 +16,6 @@ import (
 //
 //	ds.check_relation({
 //	  "object": {
-//	    "id": "",
 //	    "key": "",
 //	    "type": ""
 //	  },
@@ -25,7 +24,6 @@ import (
 //	    "object_type": ""
 //	  },
 //	  "subject": {
-//	    "id": "",
 //	    "key": "",
 //	    "type": ""
 //	  }
@@ -53,7 +51,6 @@ func RegisterCheckRelation(logger *zerolog.Logger, fnName string, dr resolvers.D
 			if a.Subject == nil && a.RelationType == nil && a.Object == nil {
 				a = args{
 					Subject: &dsc.ObjectIdentifier{
-						Id:   proto.String(""),
 						Type: proto.String(""),
 						Key:  proto.String(""),
 					},
@@ -62,7 +59,6 @@ func RegisterCheckRelation(logger *zerolog.Logger, fnName string, dr resolvers.D
 						Name:       proto.String(""),
 					},
 					Object: &dsc.ObjectIdentifier{
-						Id:   proto.String(""),
 						Type: proto.String(""),
 						Key:  proto.String(""),
 					},
@@ -94,16 +90,13 @@ func RegisterCheckRelation(logger *zerolog.Logger, fnName string, dr resolvers.D
 //
 //	ds.check_permission({
 //		"object": {
-//		  "id": "",
 //		  "key": "",
 //		  "type": ""
 //		},
 //		"permission": {
-//		  "id": "",
 //		  "name": ""
 //		},
 //		"subject": {
-//		  "id": "",
 //		  "key": "",
 //		  "type": ""
 //		}
@@ -131,16 +124,13 @@ func RegisterCheckPermission(logger *zerolog.Logger, fnName string, dr resolvers
 			if a.Subject == nil && a.Permission == nil && a.Object == nil {
 				a = args{
 					Subject: &dsc.ObjectIdentifier{
-						Id:   proto.String(""),
 						Type: proto.String(""),
 						Key:  proto.String(""),
 					},
 					Permission: &dsc.PermissionIdentifier{
-						Id:   proto.String(""),
 						Name: proto.String(""),
 					},
 					Object: &dsc.ObjectIdentifier{
-						Id:   proto.String(""),
 						Type: proto.String(""),
 						Key:  proto.String(""),
 					},

--- a/builtins/edge/ds/graph.go
+++ b/builtins/edge/ds/graph.go
@@ -18,12 +18,10 @@ import (
 //
 //	ds.graph({
 //		"anchor": {
-//		  "id": "",
 //		  "key": "",
 //		  "type": ""
 //		},
 //		"object": {
-//		  "id": "",
 //		  "key": "",
 //		  "type": ""
 //		},
@@ -32,7 +30,6 @@ import (
 //		  "object_type": ""
 //		},
 //		"subject": {
-//		  "id": "",
 //		  "key": "",
 //		  "type": ""
 //		}
@@ -60,12 +57,10 @@ func RegisterGraph(logger *zerolog.Logger, fnName string, dr resolvers.Directory
 			if a.Anchor == nil && a.Subject == nil && a.Relation == nil && a.Object == nil {
 				a = args{
 					Anchor: &dsc.ObjectIdentifier{
-						Id:   proto.String(""),
 						Type: proto.String(""),
 						Key:  proto.String(""),
 					},
 					Subject: &dsc.ObjectIdentifier{
-						Id:   proto.String(""),
 						Type: proto.String(""),
 						Key:  proto.String(""),
 					},
@@ -74,7 +69,6 @@ func RegisterGraph(logger *zerolog.Logger, fnName string, dr resolvers.Directory
 						Name:       proto.String(""),
 					},
 					Object: &dsc.ObjectIdentifier{
-						Id:   proto.String(""),
 						Type: proto.String(""),
 						Key:  proto.String(""),
 					},

--- a/builtins/edge/ds/identity.go
+++ b/builtins/edge/ds/identity.go
@@ -14,7 +14,7 @@ import (
 
 // RegisterIdentity - ds.identity
 //
-// get user id for identity
+// get user key for identity
 //
 //	ds.identity({
 //		"key": ""

--- a/builtins/edge/ds/identity.go
+++ b/builtins/edge/ds/identity.go
@@ -56,7 +56,7 @@ func RegisterIdentity(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 				return nil, err
 
 			default:
-				return ast.StringTerm(user.Id), nil
+				return ast.StringTerm(user.Key), nil
 			}
 
 			return nil, aerr.ErrDirectoryObjectNotFound

--- a/builtins/edge/ds/object.go
+++ b/builtins/edge/ds/object.go
@@ -19,7 +19,6 @@ import (
 // RegisterObject - ds.object
 //
 //	ds.object({
-//		"id": "",
 //		"key": "",
 //		"type": ""
 //	})
@@ -36,9 +35,8 @@ func RegisterObject(logger *zerolog.Logger, fnName string, dr resolvers.Director
 				return nil, err
 			}
 
-			if a.Id == nil && a.Type == nil && a.Key == nil {
+			if a.Type == nil && a.Key == nil {
 				a = &dsc.ObjectIdentifier{
-					Id:   proto.String(""),
 					Type: proto.String(""),
 					Key:  proto.String(""),
 				}

--- a/builtins/edge/ds/relation.go
+++ b/builtins/edge/ds/relation.go
@@ -20,7 +20,6 @@ import (
 //
 //	ds.relation({
 //		"object": {
-//		  "id": "",
 //		  "key": "",
 //		  "type": ""
 //		},
@@ -29,7 +28,6 @@ import (
 //		  "object_type": ""
 //		},
 //		"subject": {
-//		  "id": "",
 //		  "key": "",
 //		  "type": ""
 //		},
@@ -57,7 +55,6 @@ func RegisterRelation(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 				a = &extendedRelation{
 					RelationIdentifier: &dsc.RelationIdentifier{
 						Subject: &dsc.ObjectIdentifier{
-							Id:   proto.String(""),
 							Type: proto.String(""),
 							Key:  proto.String(""),
 						},
@@ -66,7 +63,6 @@ func RegisterRelation(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 							Name:       proto.String(""),
 						},
 						Object: &dsc.ObjectIdentifier{
-							Id:   proto.String(""),
 							Type: proto.String(""),
 							Key:  proto.String(""),
 						},

--- a/builtins/edge/ds/user.go
+++ b/builtins/edge/ds/user.go
@@ -17,7 +17,7 @@ import (
 // RegisterUser - ds.user
 //
 //	ds.user({
-//		"id": ""
+//		"key": ""
 //	})
 func RegisterUser(logger *zerolog.Logger, fnName string, dr resolvers.DirectoryResolver) (*rego.Function, rego.Builtin1) {
 	return &rego.Function{
@@ -28,7 +28,7 @@ func RegisterUser(logger *zerolog.Logger, fnName string, dr resolvers.DirectoryR
 		func(bctx rego.BuiltinContext, op1 *ast.Term) (*ast.Term, error) {
 
 			type args struct {
-				ID string `json:"id"`
+				Key string `json:"key"`
 			}
 
 			var a args
@@ -47,7 +47,7 @@ func RegisterUser(logger *zerolog.Logger, fnName string, dr resolvers.DirectoryR
 
 			resp, err := client.GetObject(bctx.Context, &dsr.GetObjectRequest{
 				Param: &dsc.ObjectIdentifier{
-					Id: &a.ID,
+					Key: &a.Key,
 				},
 			})
 			if err != nil {

--- a/directory/config.go
+++ b/directory/config.go
@@ -1,12 +1,14 @@
 package directory
 
-import (
-	"github.com/aserto-dev/go-edge-ds/pkg/directory"
-)
+import "time"
 
 type Config struct {
-	EdgeConfig directory.Config `json:"edge"`
-	Remote     struct {
+	EdgeConfig struct {
+		DBPath         string        `json:"db_path"`
+		RequestTimeout time.Duration `json:"request_timeout"`
+		Seed           bool          `json:"seed_metadata"`
+	} `json:"edge"`
+	Remote struct {
 		Addr     string `json:"address"`
 		Key      string `json:"api_key"`
 		Insecure bool   `json:"insecure"`

--- a/directory/identity.go
+++ b/directory/identity.go
@@ -3,29 +3,29 @@ package directory
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	cerr "github.com/aserto-dev/errors"
 	"github.com/aserto-dev/go-authorizer/pkg/aerr"
 	v2 "github.com/aserto-dev/go-directory/aserto/directory/common/v2"
 	ds2 "github.com/aserto-dev/go-directory/aserto/directory/reader/v2"
 	"github.com/aserto-dev/go-directory/pkg/derr"
+	"google.golang.org/protobuf/proto"
 )
 
 func GetIdentityV2(client ds2.ReaderClient, ctx context.Context, identity string) (*v2.Object, error) {
 	identityString := "identity"
-	obj := v2.ObjectIdentifier{Type: &identityString, Key: &identity}
-
-	relationString := "identifier"
 	subjectType := "user"
-	withObjects := true
+
+	obj := v2.ObjectIdentifier{Type: &identityString, Key: &identity}
 
 	relResp, err := client.GetRelation(ctx, &ds2.GetRelationRequest{
 		Param: &v2.RelationIdentifier{
 			Object:   &obj,
-			Relation: &v2.RelationTypeIdentifier{Name: &relationString, ObjectType: &identityString},
+			Relation: &v2.RelationTypeIdentifier{Name: proto.String("identifier"), ObjectType: &identityString},
 			Subject:  &v2.ObjectIdentifier{Type: &subjectType},
 		},
-		WithObjects: &withObjects,
+		WithObjects: proto.Bool(true),
 	})
 	switch {
 	case err != nil && errors.Is(cerr.UnwrapAsertoError(err), derr.ErrNotFound):
@@ -40,5 +40,5 @@ func GetIdentityV2(client ds2.ReaderClient, ctx context.Context, identity string
 		return nil, aerr.ErrDirectoryObjectNotFound.Msg("no objects found in relation")
 	}
 
-	return relResp.Objects[*relResp.Results[0].Subject.Id], nil
+	return relResp.Objects[fmt.Sprintf("%s:%s", subjectType, *relResp.Results[0].Subject.Key)], nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 // replace github.com/aserto-dev/go-edge-ds => ../go-edge-ds
 // replace github.com/aserto-dev/go-directory-cli => ../go-directory-cli
+
 // replace github.com/aserto-dev/go-aserto => ../go-aserto
 // replace github.com/aserto-dev/runtime => ../runtime
 
@@ -14,9 +15,8 @@ require (
 	github.com/aserto-dev/errors v0.0.4
 	github.com/aserto-dev/go-aserto v0.20.3
 	github.com/aserto-dev/go-authorizer v0.20.2
-	github.com/aserto-dev/go-directory v0.20.6
-	github.com/aserto-dev/go-directory-cli v0.20.11
-	github.com/aserto-dev/go-edge-ds v0.20.7
+	github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad
+	github.com/aserto-dev/go-directory-cli v0.20.12-0.20230410194201-8ce00c9fa0de
 	github.com/aserto-dev/go-http-metrics v0.10.1-20221024-1
 	github.com/aserto-dev/header v0.0.5
 	github.com/aserto-dev/logger v0.0.3
@@ -90,7 +90,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
@@ -104,6 +103,7 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
@@ -114,7 +114,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.1.0 // indirect
-	go.etcd.io/bbolt v1.3.7 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,12 +64,10 @@ github.com/aserto-dev/go-aserto v0.20.3 h1:yUhMIENFIdKA6TxE36E+99N3baEIuzfj7Y+on
 github.com/aserto-dev/go-aserto v0.20.3/go.mod h1:6e5FdSQNvVvaRVIVrAqlQk9uh5k3jtIcDIXciQtN+GQ=
 github.com/aserto-dev/go-authorizer v0.20.2 h1:jDjPeaD3lyJmgWFDL6+B8ebG9nrRsqFyMP16HVdNhj4=
 github.com/aserto-dev/go-authorizer v0.20.2/go.mod h1:RTpBixDT2WIPOkXcewCXG3NxOWDt22yiXMb+qvdxucM=
-github.com/aserto-dev/go-directory v0.20.6 h1:D8ttv2YfYUBFr+stxZ6ZXGaycw66MGb0Ooj2Lk7RH+0=
-github.com/aserto-dev/go-directory v0.20.6/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
-github.com/aserto-dev/go-directory-cli v0.20.11 h1:0Q5KDOi5c1eyXjyBSEM50UxXuBPdSti2y57lybnvOgI=
-github.com/aserto-dev/go-directory-cli v0.20.11/go.mod h1:XbOGPGxHQkF9nEBdJEaED1WA/mrFC+w/BZNkAv/hcRU=
-github.com/aserto-dev/go-edge-ds v0.20.7 h1:e05AiQGGbPv8H8F+8a4oO2o9WRDZEYCV0h5gFhQoHKs=
-github.com/aserto-dev/go-edge-ds v0.20.7/go.mod h1:6ZJxuMpNGYE5WKhPsroOXaEqxoXY1mqFWxAFfA+VPPA=
+github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad h1:Ay40WBmZW8AR3U1JVj6un4szszu3XIxgwhH5Ew6OYkE=
+github.com/aserto-dev/go-directory v0.20.7-0.20230322222720-bd21a6431aad/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
+github.com/aserto-dev/go-directory-cli v0.20.12-0.20230410194201-8ce00c9fa0de h1:Hy851iZab3yhxaKwOoSIrlovpx5G715+Gzk5e6NZq9A=
+github.com/aserto-dev/go-directory-cli v0.20.12-0.20230410194201-8ce00c9fa0de/go.mod h1:aypkQA7ReNQ7ozNOooZeAtLJ31nWH/VUgRm6ShZvleY=
 github.com/aserto-dev/go-http-metrics v0.10.1-20221024-1 h1:nONd24V5nyJ0IIw8QE+OKv30YuHOTNbJ4FsvczLaM8o=
 github.com/aserto-dev/go-http-metrics v0.10.1-20221024-1/go.mod h1:QnWF5/X2U/kmbu7GEw+zupvqX2hIthDjyXlRTwt2zEI=
 github.com/aserto-dev/header v0.0.5 h1:nEvYNgBoIwomxuvo14JuQ/ZqGGHU67NKuZyNdW4n4FU=
@@ -337,8 +335,6 @@ github.com/mennanov/fmutils v0.2.0/go.mod h1:DE+qeI9Xy5s1GA4trgq8H26jr5DgJ4a9+0D
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
-github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -415,6 +411,7 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
 github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -468,8 +465,6 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
-go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go.work.sum
+++ b/go.work.sum
@@ -172,8 +172,11 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aserto-dev/aserto-go v0.8.14-0.20221018123009-a56db85a7ed3 h1:Kp2Ojrem4ixQEQYaxtUiR2RAW6HnQCastADjO3VOJOQ=
 github.com/aserto-dev/aserto-grpc v0.1.1 h1:iILD2u0yjHdibBsG7CchkiudUmwvNhBmPUN7kNm9cvM=
-github.com/aserto-dev/mage-loot v0.8.13 h1:i8kRhcwnbTd6MB8rDxg/JZ53aWs09srIPQSttO8joJo=
-github.com/aserto-dev/mage-loot v0.8.13/go.mod h1:Oi7gxbSzxC4qlCMUaiNHWLE1DjmcMTk96fzFHNN/bsc=
+github.com/aserto-dev/errors v0.0.2/go.mod h1:TBlc5z9t1ClYehyJT614pJ0jknkCFWo7sdyAFkFEndY=
+github.com/aserto-dev/go-directory v0.20.6 h1:D8ttv2YfYUBFr+stxZ6ZXGaycw66MGb0Ooj2Lk7RH+0=
+github.com/aserto-dev/go-directory v0.20.6/go.mod h1:gjg6wZezLGXJj1LBEXaJUS9kpOnaDWeFUYhDG1TAkTY=
+github.com/aserto-dev/go-directory-cli v0.20.12-0.20230410194201-8ce00c9fa0de h1:Hy851iZab3yhxaKwOoSIrlovpx5G715+Gzk5e6NZq9A=
+github.com/aserto-dev/go-directory-cli v0.20.12-0.20230410194201-8ce00c9fa0de/go.mod h1:aypkQA7ReNQ7ozNOooZeAtLJ31nWH/VUgRm6ShZvleY=
 github.com/aserto-dev/runtime v0.47.3 h1:KEXQ5bFImIWAqUM5uIPDQ94zeHYScalhWziu+GAqRzk=
 github.com/aserto-dev/runtime v0.47.3/go.mod h1:0iis95JxPIOPQvdmS0+zJnhCPLrz3bkinFNzDtbwuak=
 github.com/aserto-dev/runtime v0.51.0 h1:bJPCP5v0nY1NS1t4q3+1TSf6WA+wQorTXRiD8UQP+QY=
@@ -269,6 +272,7 @@ github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.14.0/go.mod h1:4OGVnY4qf2+gw+ssiHbW+pq4mo2yko94YxxMmXZ7jCA=
 github.com/hashicorp/consul/api v1.15.3/go.mod h1:/g/qgcoBcEXALCNZgRRisyTW0nY86++L0KbeAMXYCeY=
 github.com/hashicorp/consul/api v1.18.0/go.mod h1:owRRGJ9M5xReDC5nfT8FTJrNAPbT4NM6p/k+d03q2v4=
 github.com/hashicorp/consul/sdk v0.11.0/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
@@ -388,6 +392,7 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/etcd/api/v3 v3.5.5/go.mod h1:KFtNaxGDw4Yx/BA4iPPwevUTAuqcsPxzyX8PHydchN8=
 go.etcd.io/etcd/api/v3 v3.5.6/go.mod h1:KFtNaxGDw4Yx/BA4iPPwevUTAuqcsPxzyX8PHydchN8=
 go.etcd.io/etcd/client/pkg/v3 v3.5.5/go.mod h1:ggrwbk069qxpKPq8/FKkQ3Xq9y39kbFR4LnKszpRXeQ=
@@ -619,6 +624,7 @@ google.golang.org/genproto v0.0.0-20220920201722-2b89144ce006/go.mod h1:ht8XFiar
 google.golang.org/genproto v0.0.0-20220927151529-dcaddaf36704/go.mod h1:woMGP53BroOrRY3xTxlbr8Y3eB/nzAvvFM83q7kG2OI=
 google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e/go.mod h1:9qHF0xnpdSfF6knlcsnpzUu5y+rpwgbvsyGAZPBMg4s=
 google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c/go.mod h1:CGI5F/G+E5bKwmfYo09AXuVN4dD894kIKUFmVbP2/Fo=
+google.golang.org/genproto v0.0.0-20221114212237-e4508ebdbee1/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -42,8 +42,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/aserto-dev/clui v0.8.1 h1:5IW9OnFZoIWjvnmTE4FNTXrjP1wnMzd39qKAcRnRHt8=
 github.com/aserto-dev/clui v0.8.1/go.mod h1:XpJxwNzSQaGN6rqXONZJEaeez4MUaCPikM2lKSngrXM=
-github.com/aserto-dev/mage-loot v0.8.11 h1:3Xs/vF44SMeMU571Gnm/NCyOm4M+m1g/l091nMqzbTU=
-github.com/aserto-dev/mage-loot v0.8.11/go.mod h1:Oi7gxbSzxC4qlCMUaiNHWLE1DjmcMTk96fzFHNN/bsc=
+github.com/aserto-dev/mage-loot v0.8.13 h1:i8kRhcwnbTd6MB8rDxg/JZ53aWs09srIPQSttO8joJo=
+github.com/aserto-dev/mage-loot v0.8.13/go.mod h1:Oi7gxbSzxC4qlCMUaiNHWLE1DjmcMTk96fzFHNN/bsc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/pkg/app/authorizer.go
+++ b/pkg/app/authorizer.go
@@ -2,10 +2,7 @@ package app
 
 import (
 	"context"
-	"strconv"
-	"strings"
 
-	edgeServer "github.com/aserto-dev/go-edge-ds/pkg/server"
 	"github.com/aserto-dev/topaz/pkg/app/server"
 	"github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/aserto-dev/topaz/resolvers"
@@ -25,31 +22,31 @@ type Authorizer struct {
 
 // Start starts all services required by the engine.
 func (e *Authorizer) Start() error {
-	if (strings.Contains(e.Configuration.Directory.Remote.Addr, "localhost") || strings.Contains(e.Configuration.Directory.Remote.Addr, "0.0.0.0")) &&
-		e.Configuration.Directory.EdgeConfig.DBPath != "" {
-		addr := strings.Split(e.Configuration.Directory.Remote.Addr, ":")
-		if len(addr) != 2 {
-			return errors.Errorf("invalid remote address - should contain <host>:<port>")
-		}
+	// if (strings.Contains(e.Configuration.Directory.Remote.Addr, "localhost") || strings.Contains(e.Configuration.Directory.Remote.Addr, "0.0.0.0")) &&
+	//     e.Configuration.Directory.EdgeConfig.DBPath != "" {
+	//     addr := strings.Split(e.Configuration.Directory.Remote.Addr, ":")
+	//     if len(addr) != 2 {
+	//         return errors.Errorf("invalid remote address - should contain <host>:<port>")
+	//     }
 
-		port, err := strconv.Atoi(addr[1])
-		if err != nil {
-			return err
-		}
+	//     port, err := strconv.Atoi(addr[1])
+	//     if err != nil {
+	//         return err
+	//     }
 
-		edge, err := edgeServer.NewEdgeServer(
-			e.Configuration.Directory.EdgeConfig,
-			&e.Configuration.API.GRPC.Certs,
-			addr[0],
-			port,
-			e.Logger,
-		)
-		if err != nil {
-			return errors.Wrap(err, "failed to create edge directory server")
-		}
+	//     edge, err := edgeServer.NewEdgeServer(
+	//         e.Configuration.Directory.EdgeConfig,
+	//         &e.Configuration.API.GRPC.Certs,
+	//         addr[0],
+	//         port,
+	//         e.Logger,
+	//     )
+	//     if err != nil {
+	//         return errors.Wrap(err, "failed to create edge directory server")
+	//     }
 
-		e.Server.RegisterServer("edgeDirServer", edge.Start, edge.Stop)
-	}
+	//     e.Server.RegisterServer("edgeDirServer", edge.Start, edge.Stop)
+	// }
 
 	err := e.Server.Start(e.Context)
 	if err != nil {

--- a/pkg/app/impl/jwt.go
+++ b/pkg/app/impl/jwt.go
@@ -189,20 +189,20 @@ func (s *AuthorizerServer) getUserFromIdentity(ctx context.Context, identity str
 	}
 
 	if user == nil {
-		return s.getObject(ctx, identity)
+		return s.getObject(ctx, "identity", identity)
 	}
 
 	return user, nil
 }
 
-func (s *AuthorizerServer) getObject(ctx context.Context, id string) (proto.Message, error) {
+func (s *AuthorizerServer) getObject(ctx context.Context, objType, key string) (proto.Message, error) {
 	client, err := s.resolver.GetDirectoryResolver().GetDS(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	objResp, err := client.GetObject(ctx, &ds2.GetObjectRequest{
-		Param: &v2.ObjectIdentifier{Id: &id},
+		Param: &v2.ObjectIdentifier{Type: &objType, Key: &key},
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/app/impl/jwt.go
+++ b/pkg/app/impl/jwt.go
@@ -189,7 +189,7 @@ func (s *AuthorizerServer) getUserFromIdentity(ctx context.Context, identity str
 	}
 
 	if user == nil {
-		return s.getObject(ctx, "identity", identity)
+		return s.getObject(ctx, "user", identity)
 	}
 
 	return user, nil


### PR DESCRIPTION
This PR switches topaz to [pb-directory 0.21](https://github.com/aserto-dev/pb-directory/tree/0.21).
The dependency on go-edge-ds is temporarily removed until a versions compatible with 0.21 is available.