### PR TITLE
updated citadel assets to remove manager relations, extra groups

### DIFF
--- a/assets/citadel-objects.json
+++ b/assets/citadel-objects.json
@@ -1,26 +1,6 @@
 {
   "objects": [
     {
-      "id": "02413666-e4b6-4252-b159-bda1237e8605",
-      "key": "son",
-      "type": "group",
-      "displayName": "son-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.822538Z",
-      "updatedAt": "2022-08-16T01:40:00.822538Z",
-      "hash": "6288928913882501605"
-    },
-    {
-      "id": "11313c73-20ed-40de-bca8-dba0c6228b4d",
-      "key": "grandson",
-      "type": "group",
-      "displayName": "grandson-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.807157Z",
-      "updatedAt": "2022-08-16T01:40:00.807157Z",
-      "hash": "3706240744748239269"
-    },
-    {
       "id": "159cb08f-f053-4b39-a2e5-510e4496b584",
       "key": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
       "type": "identity",
@@ -34,16 +14,6 @@
       "hash": "14794701420750924447"
     },
     {
-      "id": "24eea568-3f92-460d-98d5-e244ff5caa3a",
-      "key": "sideckick",
-      "type": "group",
-      "displayName": "sideckick-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.815258Z",
-      "updatedAt": "2022-08-16T01:40:00.815258Z",
-      "hash": "16067010568483411777"
-    },
-    {
       "id": "30004736-4f22-4586-a33b-aa6166722277",
       "key": "admin",
       "type": "group",
@@ -52,56 +22,6 @@
       "createdAt": "2022-08-16T01:40:00.754761Z",
       "updatedAt": "2022-08-16T01:40:00.754761Z",
       "hash": "12281804642046024123"
-    },
-    {
-      "id": "306cb90a-1668-4cc2-b059-48ac09aab48b",
-      "key": "sister",
-      "type": "group",
-      "displayName": "sister-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.864530Z",
-      "updatedAt": "2022-08-16T01:40:00.864530Z",
-      "hash": "1803172163862510081"
-    },
-    {
-      "id": "3371a855-f95c-4341-9947-7974ffdba55f",
-      "key": "squanch",
-      "type": "group",
-      "displayName": "squanch-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.766796Z",
-      "updatedAt": "2022-08-16T01:40:00.766796Z",
-      "hash": "12357154632452340447"
-    },
-    {
-      "id": "3ad81a9a-7d5a-4847-b9bf-c36bf9626f00",
-      "key": "looser",
-      "type": "group",
-      "displayName": "looser-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.940168Z",
-      "updatedAt": "2022-08-16T01:40:00.940168Z",
-      "hash": "14925407559164434985"
-    },
-    {
-      "id": "40a3f000-523c-47b3-a35e-2e23686fe4f3",
-      "key": "little_helper",
-      "type": "group",
-      "displayName": "little_helper-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.811296Z",
-      "updatedAt": "2022-08-16T01:40:00.811296Z",
-      "hash": "194265659644214395"
-    },
-    {
-      "id": "4a927759-4b82-4626-bb3f-460e12a84fc5",
-      "key": "daughter",
-      "type": "group",
-      "displayName": "daughter-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.848415Z",
-      "updatedAt": "2022-08-16T01:40:00.848415Z",
-      "hash": "8917608138779707489"
     },
     {
       "id": "4f21420f-d58e-4963-9d19-4796f0dbe668",
@@ -128,36 +48,6 @@
       "createdAt": "2022-08-16T01:25:08.273376Z",
       "updatedAt": "2022-09-22T20:27:18.709644Z",
       "hash": "14198950188700989561"
-    },
-    {
-      "id": "5fb2efb0-1fcd-41b4-b007-649f0835f5d9",
-      "key": "clone",
-      "type": "group",
-      "displayName": "clone-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.896693Z",
-      "updatedAt": "2022-08-16T01:40:00.896693Z",
-      "hash": "1227307795273372287"
-    },
-    {
-      "id": "6beda8ad-e909-44df-b7cf-a56c2a1b109e",
-      "key": "grandpa",
-      "type": "group",
-      "displayName": "grandpa-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.763188Z",
-      "updatedAt": "2022-08-16T01:40:00.763188Z",
-      "hash": "6911103132217431939"
-    },
-    {
-      "id": "6c93650b-1823-4b9d-82e4-221b8bdd634c",
-      "key": "mom",
-      "type": "group",
-      "displayName": "mom-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.903932Z",
-      "updatedAt": "2022-08-16T01:40:00.903932Z",
-      "hash": "15860240549074363663"
     },
     {
       "id": "6ce1b908-4ddc-4a26-92fa-1c470ff3e851",
@@ -191,16 +81,6 @@
       "createdAt": "2022-08-16T01:40:00.907379Z",
       "updatedAt": "2022-08-16T01:40:00.907379Z",
       "hash": "4195410253752275865"
-    },
-    {
-      "id": "9ee93ac7-9917-4e71-8e4f-3757b63421b5",
-      "key": "granddaughter",
-      "type": "group",
-      "displayName": "granddaughter-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.855600Z",
-      "updatedAt": "2022-08-16T01:40:00.855600Z",
-      "hash": "13591967038724083041"
     },
     {
       "id": "a81e1157-b75e-45fe-b2fc-1e6fed52fe4e",
@@ -242,26 +122,6 @@
       "hash": "5105893942507759315"
     },
     {
-      "id": "afdcac01-a763-4873-b1ee-3b82e05d55b3",
-      "key": "dad",
-      "type": "group",
-      "displayName": "dad-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.936351Z",
-      "updatedAt": "2022-08-16T01:40:00.936351Z",
-      "hash": "3161815676707525147"
-    },
-    {
-      "id": "b4facddd-44b3-40e4-b7a0-0fbae7d91b51",
-      "key": "brother",
-      "type": "group",
-      "displayName": "brother-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.798790Z",
-      "updatedAt": "2022-08-16T01:40:00.798790Z",
-      "hash": "17401397119882303529"
-    },
-    {
       "id": "c9ed5437-2d63-477c-b6e5-64ff635238cd",
       "key": "beth@the-smiths.com",
       "type": "identity",
@@ -296,16 +156,6 @@
       "createdAt": "2022-08-16T01:40:00.803541Z",
       "updatedAt": "2022-08-16T01:40:00.803541Z",
       "hash": "8551884661867706901"
-    },
-    {
-      "id": "df7a7f9d-98e3-4d47-b5da-b4d06b1d05c2",
-      "key": "sidekick",
-      "type": "group",
-      "displayName": "sidekick-group",
-      "properties": {},
-      "createdAt": "2022-08-16T01:40:00.818574Z",
-      "updatedAt": "2022-08-16T01:40:00.818574Z",
-      "hash": "8575396143000946749"
     },
     {
       "id": "e100a8e3-736d-4c48-aeb5-c6cc26518911",

--- a/assets/citadel-relations.json
+++ b/assets/citadel-relations.json
@@ -3,34 +3,6 @@
     {
       "subject": {
         "type": "user",
-        "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "02413666-e4b6-4252-b159-bda1237e8605"
-      },
-      "createdAt": "2022-08-16T01:40:00.824473Z",
-      "updatedAt": "2022-08-16T01:40:00.824473Z",
-      "hash": "8053499315999481419"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "11313c73-20ed-40de-bca8-dba0c6228b4d"
-      },
-      "createdAt": "2022-08-16T01:40:00.809294Z",
-      "updatedAt": "2022-08-16T01:40:00.809294Z",
-      "hash": "4655743704993058308"
-    },
-    {
-      "subject": {
-        "type": "user",
         "id": "fd4614d3-c39a-4781-b7bd-8b96f5a5100d"
       },
       "relation": "identifier",
@@ -45,34 +17,6 @@
     {
       "subject": {
         "type": "user",
-        "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "24eea568-3f92-460d-98d5-e244ff5caa3a"
-      },
-      "createdAt": "2022-08-16T01:40:00.816803Z",
-      "updatedAt": "2022-08-16T01:40:00.816803Z",
-      "hash": "8556730136479125385"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "24eea568-3f92-460d-98d5-e244ff5caa3a"
-      },
-      "createdAt": "2022-08-16T01:40:00.860132Z",
-      "updatedAt": "2022-08-16T01:40:00.860132Z",
-      "hash": "10225948017196205242"
-    },
-    {
-      "subject": {
-        "type": "user",
         "id": "fd0614d3-c39a-4781-b7bd-8b96f5a5100d"
       },
       "relation": "member",
@@ -83,104 +27,6 @@
       "createdAt": "2022-08-16T01:40:00.757151Z",
       "updatedAt": "2022-08-16T01:40:00.757151Z",
       "hash": "11764758546195978740"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "306cb90a-1668-4cc2-b059-48ac09aab48b"
-      },
-      "createdAt": "2022-08-16T01:40:00.866458Z",
-      "updatedAt": "2022-08-16T01:40:00.866458Z",
-      "hash": "7055539142679996193"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd0614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "3371a855-f95c-4341-9947-7974ffdba55f"
-      },
-      "createdAt": "2022-08-16T01:40:00.768726Z",
-      "updatedAt": "2022-08-16T01:40:00.768726Z",
-      "hash": "14574029214709532226"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "3371a855-f95c-4341-9947-7974ffdba55f"
-      },
-      "createdAt": "2022-08-16T01:40:00.869545Z",
-      "updatedAt": "2022-08-16T01:40:00.869545Z",
-      "hash": "13752407861311866060"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd4614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "3ad81a9a-7d5a-4847-b9bf-c36bf9626f00"
-      },
-      "createdAt": "2022-08-16T01:40:00.941866Z",
-      "updatedAt": "2022-08-16T01:40:00.941866Z",
-      "hash": "12227707670778460209"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "40a3f000-523c-47b3-a35e-2e23686fe4f3"
-      },
-      "createdAt": "2022-08-16T01:40:00.813285Z",
-      "updatedAt": "2022-08-16T01:40:00.813285Z",
-      "hash": "9577347592201082401"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "4a927759-4b82-4626-bb3f-460e12a84fc5"
-      },
-      "createdAt": "2022-08-16T01:40:00.850601Z",
-      "updatedAt": "2022-08-16T01:40:00.850601Z",
-      "hash": "16246060454047924157"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd3614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "4a927759-4b82-4626-bb3f-460e12a84fc5"
-      },
-      "createdAt": "2022-08-16T01:40:00.901812Z",
-      "updatedAt": "2022-08-16T01:40:00.901812Z",
-      "hash": "7940233130203938696"
     },
     {
       "subject": {
@@ -209,48 +55,6 @@
       "createdAt": "2022-08-16T01:25:08.276564Z",
       "updatedAt": "2022-08-16T01:25:08.276564Z",
       "hash": "16147799548625896268"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd3614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "5fb2efb0-1fcd-41b4-b007-649f0835f5d9"
-      },
-      "createdAt": "2022-08-16T01:40:00.898651Z",
-      "updatedAt": "2022-08-16T01:40:00.898651Z",
-      "hash": "7173945958202329761"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd0614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "6beda8ad-e909-44df-b7cf-a56c2a1b109e"
-      },
-      "createdAt": "2022-08-16T01:40:00.764836Z",
-      "updatedAt": "2022-08-16T01:40:00.764836Z",
-      "hash": "12710272975523219885"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd3614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "6c93650b-1823-4b9d-82e4-221b8bdd634c"
-      },
-      "createdAt": "2022-08-16T01:40:00.905687Z",
-      "updatedAt": "2022-08-16T01:40:00.905687Z",
-      "hash": "11785456543041645571"
     },
     {
       "subject": {
@@ -313,20 +117,6 @@
         "type": "user",
         "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
       },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "9ee93ac7-9917-4e71-8e4f-3757b63421b5"
-      },
-      "createdAt": "2022-08-16T01:40:00.857327Z",
-      "updatedAt": "2022-08-16T01:40:00.857327Z",
-      "hash": "2176646433507279940"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
       "relation": "identifier",
       "object": {
         "type": "identity",
@@ -363,34 +153,6 @@
       "createdAt": "2022-08-16T01:25:08.468638Z",
       "updatedAt": "2022-08-16T01:25:08.468638Z",
       "hash": "11757822623391030144"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd4614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "afdcac01-a763-4873-b1ee-3b82e05d55b3"
-      },
-      "createdAt": "2022-08-16T01:40:00.938281Z",
-      "updatedAt": "2022-08-16T01:40:00.938281Z",
-      "hash": "18266491925388311426"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "b4facddd-44b3-40e4-b7a0-0fbae7d91b51"
-      },
-      "createdAt": "2022-08-16T01:40:00.801155Z",
-      "updatedAt": "2022-08-16T01:40:00.801155Z",
-      "hash": "5329278378291993041"
     },
     {
       "subject": {
@@ -451,34 +213,6 @@
     {
       "subject": {
         "type": "user",
-        "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "df7a7f9d-98e3-4d47-b5da-b4d06b1d05c2"
-      },
-      "createdAt": "2022-08-16T01:40:00.820264Z",
-      "updatedAt": "2022-08-16T01:40:00.820264Z",
-      "hash": "2024393049820369929"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "member",
-      "object": {
-        "type": "group",
-        "id": "df7a7f9d-98e3-4d47-b5da-b4d06b1d05c2"
-      },
-      "createdAt": "2022-08-16T01:40:00.862850Z",
-      "updatedAt": "2022-08-16T01:40:00.862850Z",
-      "hash": "3693610930537449786"
-    },
-    {
-      "subject": {
-        "type": "user",
         "id": "fd0614d3-c39a-4781-b7bd-8b96f5a5100d"
       },
       "relation": "identifier",
@@ -489,48 +223,6 @@
       "createdAt": "2022-08-16T01:25:08.337276Z",
       "updatedAt": "2022-08-16T01:25:08.337276Z",
       "hash": "16208746058712683486"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "manager",
-      "object": {
-        "type": "user",
-        "id": "fd0614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "createdAt": "2022-08-16T01:40:02.159692Z",
-      "updatedAt": "2022-08-16T01:40:02.159692Z",
-      "hash": "1921571884948373516"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "manager",
-      "object": {
-        "type": "user",
-        "id": "fd0614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "createdAt": "2022-08-16T01:40:02.036791Z",
-      "updatedAt": "2022-08-16T01:40:02.036791Z",
-      "hash": "10677306548984316223"
-    },
-    {
-      "subject": {
-        "type": "user",
-        "id": "fd4614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "relation": "manager",
-      "object": {
-        "type": "user",
-        "id": "fd3614d3-c39a-4781-b7bd-8b96f5a5100d"
-      },
-      "createdAt": "2022-08-16T01:40:02.100670Z",
-      "updatedAt": "2022-08-16T01:40:02.100670Z",
-      "hash": "11305083013172503214"
     }
   ]
 }


### PR DESCRIPTION
This PR cleans up the citadel objects and relations json assets.

It removes manage relations completely. It also removes extraneous groups, and associated relations between users and the removed groups.
