### PR TITLE
fixed typo locahost -> localhost in config examples

### DIFF
--- a/docs/examples/config-private-ghcr.yaml
+++ b/docs/examples/config-private-ghcr.yaml
@@ -18,7 +18,7 @@ directory_service:
 api:
   gateway:
     allowed_origins:
-    - https://locahost
+    - https://localhost
   grpc:
     connection_timeout_seconds: 2
 

--- a/docs/examples/config-remote-dir.yaml
+++ b/docs/examples/config-remote-dir.yaml
@@ -16,7 +16,7 @@ directory_service:
 api:
   gateway:
     allowed_origins:
-    - https://locahost
+    - https://localhost
   grpc:
     connection_timeout_seconds: 2
 

--- a/pkg/testing/assets/config-example.yaml
+++ b/pkg/testing/assets/config-example.yaml
@@ -14,7 +14,7 @@ directory_service:
 api:
   gateway:
     allowed_origins:
-    - https://locahost
+    - https://localhost
   grpc:
     connection_timeout_seconds: 2
 


### PR DESCRIPTION
The config file examples all have "locahost" in the allowed origins.

This PR fixes the occurrences in the Topaz repo.