### PR TITLE
Viper env key replacer should replace '.', not '-'

### DIFF
--- a/pkg/cc/config/config.go
+++ b/pkg/cc/config/config.go
@@ -98,7 +98,7 @@ func NewConfig(configPath Path, log *zerolog.Logger, overrides Overrider, certsG
 	v.AddConfigPath(".")
 	v.SetConfigFile(file)
 	v.SetEnvPrefix("TOPAZ")
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	// Set defaults
 	v.SetDefault("jwt.acceptable_time_skew_seconds", 5)


### PR DESCRIPTION
We use dot (`'.'`) as the delimiter in our viper configuration (e.g. `v.SetDefault("api.grpc.listen_address", "0.0.0.0:8282")`) but we're configuring viper to replace underscores in environment variable names with a dash (`'-'`).
This PR fixes the mismatch.

This is a port from https://github.com/aserto-dev/directory/pull/329