### PR TITLE
add topaz version --container

### DIFF
--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -2,12 +2,9 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
-	"github.com/aserto-dev/topaz/pkg/cli/x"
-	"github.com/aserto-dev/topaz/pkg/version"
 )
 
 var ErrNotRunning = errors.New("topaz is not running, use 'topaz start' or 'topaz run' to start")
@@ -30,17 +27,6 @@ type CLI struct {
 	Uninstall UninstallCmd `cmd:"" help:"uninstall topaz container"`
 	Version   VersionCmd   `cmd:"" help:"version information"`
 	NoCheck   bool         `name:"no-check" env:"TOPAZ_NO_CHECK" help:"disable local container status check"`
-}
-
-type VersionCmd struct{}
-
-func (cmd *VersionCmd) Run(c *cc.CommonCtx) error {
-	fmt.Fprintf(c.UI.Output(), "%s - %s (%s)\n",
-		x.AppName,
-		version.GetInfo().String(),
-		x.AppVersionTag,
-	)
-	return nil
 }
 
 func CheckRunning(c *cc.CommonCtx) error {

--- a/pkg/cli/cmd/version.go
+++ b/pkg/cli/cmd/version.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
+	"github.com/aserto-dev/topaz/pkg/cli/x"
+	"github.com/aserto-dev/topaz/pkg/version"
+)
+
+type VersionCmd struct {
+	Container        bool   `short:"c" help:"display topazd container version" default:"false"`
+	ContainerName    string `optional:"" default:"topaz" help:"container name"`
+	ContainerVersion string `optional:"" default:"latest" help:"container version"`
+	Platform         string `optional:"" default:"linux/amd64" help:"set platform if server is multi-platform capable"`
+}
+
+func (cmd *VersionCmd) Run(c *cc.CommonCtx) error {
+	fmt.Fprintf(c.UI.Output(), "%s %s\n",
+		x.AppName,
+		version.GetInfo().String(),
+	)
+
+	if !cmd.Container {
+		return nil
+	}
+
+	env := map[string]string{}
+
+	// default command
+	// docker run -ti --rm --name topazd-version --platform=linux/arm64 ghcr.io/aserto-dev/topaz:latest version
+	args := []string{
+		"run",
+		"-ti",
+		"--rm",
+		"--name", "topazd-version",
+		"--platform=" + cmd.Platform,
+		"ghcr.io/aserto-dev/" + cmd.ContainerName + ":" + cmd.ContainerVersion,
+		"version",
+	}
+
+	result, err := dockerx.DockerWithOut(env, args...)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(c.UI.Output(), "%s\n", result)
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -42,7 +42,7 @@ func GetInfo() Info {
 
 // String() -- return version info string.
 func (vi Info) String() string {
-	return fmt.Sprintf("%s g%s %s-%s [%s]",
+	return fmt.Sprintf("%s %s %s-%s [%s]",
 		vi.Version,
 		vi.Commit,
 		runtime.GOOS,


### PR DESCRIPTION
Add topaz version --container or -c to display the version of the container image

```
Usage: topaz version

version information

Flags:
  -h, --help                          Show context-sensitive help.
      --no-check                      disable local container status check ($TOPAZ_NO_CHECK)

  -c, --container                     display topazd container version
      --container-name="topaz"        container name
      --container-version="latest"    container version
      --platform="linux/amd64"        set platform if server is multi-platform capable
```

Example usage:
```
> topaz version --container

topaz v0.25.14 6b9fdb3 darwin-arm64 [2023-09-21T01:29:32Z]
topazd 0.25.14
```

