### PR TITLE
added role properties and manager relationship

### DIFF
--- a/assets/citadel-objects.json
+++ b/assets/citadel-objects.json
@@ -121,7 +121,8 @@
       "properties": {
         "email": "rick@the-citadel.com",
         "picture": "https://github.com/aserto-demo/contoso-ad-sample/raw/main/UserImages/Rick%20Sanchez.jpg",
-        "status": "USER_STATUS_ACTIVE"
+        "status": "USER_STATUS_ACTIVE",
+        "roles": ["admin", "evil_genius"]
       }
     },
     {
@@ -131,7 +132,8 @@
       "properties": {
         "email": "morty@the-citadel.com",
         "picture": "https://github.com/aserto-demo/contoso-ad-sample/raw/main/UserImages/Morty%20Smith.jpg",
-        "status": "USER_STATUS_ACTIVE"
+        "status": "USER_STATUS_ACTIVE",
+        "roles": ["editor"]
       }
     },
     {
@@ -141,7 +143,8 @@
       "properties": {
         "email": "summer@the-smiths.com",
         "picture": "https://github.com/aserto-demo/contoso-ad-sample/raw/main/UserImages/Summer%20Smith.jpg",
-        "status": "USER_STATUS_ACTIVE"
+        "status": "USER_STATUS_ACTIVE",
+        "roles": ["editor"]
       }
     },
     {
@@ -151,7 +154,8 @@
       "properties": {
         "email": "beth@the-smiths.com",
         "picture": "https://github.com/aserto-demo/contoso-ad-sample/raw/main/UserImages/Beth%20Smith.jpg",
-        "status": "USER_STATUS_ACTIVE"
+        "status": "USER_STATUS_ACTIVE",
+        "roles": ["viewer"]
       }
     },
     {
@@ -161,7 +165,8 @@
       "properties": {
         "email": "jerry@the-smiths.com",
         "picture": "https://github.com/aserto-demo/contoso-ad-sample/raw/main/UserImages/Jerry%20Smith.jpg",
-        "status": "USER_STATUS_ACTIVE"
+        "status": "USER_STATUS_ACTIVE",
+        "roles": ["viewer"]
       }
     }
   ]

--- a/assets/citadel-relations.json
+++ b/assets/citadel-relations.json
@@ -168,6 +168,50 @@
     {
       "subject": {
         "type": "user",
+        "key": "summer@the-smiths.com"
+      },
+      "relation": "manager",
+      "object": {
+        "type": "user",
+        "key": "rick@the-citadel.com"
+      }
+    },
+    {
+      "subject": {
+        "type": "user",
+        "key": "morty@the-citadel.com"
+      },
+      "relation": "manager",
+      "object": {
+        "type": "user",
+        "key": "rick@the-citadel.com"
+      }
+    },
+    {
+      "subject": {
+        "type": "user",
+        "key": "beth@the-smiths.com"
+      },
+      "relation": "manager",
+      "object": {
+        "type": "user",
+        "key": "rick@the-citadel.com"
+      }
+    },
+    {
+      "subject": {
+        "type": "user",
+        "key": "jerry@the-smiths.com"
+      },
+      "relation": "manager",
+      "object": {
+        "type": "user",
+        "key": "beth@the-smiths.com"
+      }
+    },
+    {
+      "subject": {
+        "type": "user",
         "key": "rick@the-citadel.com"
       },
       "relation": "identifier",


### PR DESCRIPTION
The latest citadel data seems to have a regression where the roles property was removed. This breaks the todo sample policy, which relies on roles, and that we provision as a default artifact.  New signups are hitting this.

This PR adds back the roles property for the users, and also the manager relationships (since they are no longer evaluating wrong). 