### PR TITLE
topaz cli add --format for versioned commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/aserto-dev/go-aserto v0.30.0
 	github.com/aserto-dev/go-authorizer v0.20.3
 	github.com/aserto-dev/go-directory v0.30.2
-	github.com/aserto-dev/go-directory-cli v0.30.1-0.20231105222812-42a7b4f12a85
-	github.com/aserto-dev/go-edge-ds v0.30.0
+	github.com/aserto-dev/go-directory-cli v0.30.1
+	github.com/aserto-dev/go-edge-ds v0.30.1
 	github.com/aserto-dev/go-grpc v0.8.58
 	github.com/aserto-dev/header v0.0.5
 	github.com/aserto-dev/logger v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aserto-dev/go-aserto v0.30.0
 	github.com/aserto-dev/go-authorizer v0.20.3
 	github.com/aserto-dev/go-directory v0.30.2
-	github.com/aserto-dev/go-directory-cli v0.30.0
+	github.com/aserto-dev/go-directory-cli v0.30.1-0.20231105222812-42a7b4f12a85
 	github.com/aserto-dev/go-edge-ds v0.30.0
 	github.com/aserto-dev/go-grpc v0.8.58
 	github.com/aserto-dev/header v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -432,10 +432,10 @@ github.com/aserto-dev/go-decision-logs v0.0.4 h1:beu/mhqZ92ovhSIPOv2f4q0Ci7HWNLl
 github.com/aserto-dev/go-decision-logs v0.0.4/go.mod h1:W50DNu4HPCk+iyI39cP3+KBytdrQYVieSPXh9StuRzA=
 github.com/aserto-dev/go-directory v0.30.2 h1:cUkvzma8paV2YFaCIvjfy1a9DMNCx5qV3EjcLo68RuA=
 github.com/aserto-dev/go-directory v0.30.2/go.mod h1:jHn6ckERuci6nWz9vCzAbYoF2UnbOwEzl++sA1L3nyc=
-github.com/aserto-dev/go-directory-cli v0.30.1-0.20231105222812-42a7b4f12a85 h1:JpC1cCNZKCBPcb6WeSZtXgXZA5IUtGQXbAWDW+Fy8Xg=
-github.com/aserto-dev/go-directory-cli v0.30.1-0.20231105222812-42a7b4f12a85/go.mod h1:EvTAQdfREB8Wq5aRJxk3krkBz6/4LUwJjfbc0MjVUl8=
-github.com/aserto-dev/go-edge-ds v0.30.0 h1:2o1ixUEDEQMEj/5Tk6HcXgirXKhi9GoG470YO4n6eDY=
-github.com/aserto-dev/go-edge-ds v0.30.0/go.mod h1:yKjKFm2u7zz3u/MmrOYq1mugsC2trE3diA+WkQrkvvc=
+github.com/aserto-dev/go-directory-cli v0.30.1 h1:5tEDG7uj//NXEzKkF4cbQbsvPuZzn/3hrhTA0GuG/7A=
+github.com/aserto-dev/go-directory-cli v0.30.1/go.mod h1:EvTAQdfREB8Wq5aRJxk3krkBz6/4LUwJjfbc0MjVUl8=
+github.com/aserto-dev/go-edge-ds v0.30.1 h1:Y8GfQMB/ePoMD54uiWVA3Q8BqlFkRyNu+jGlTbgBYuA=
+github.com/aserto-dev/go-edge-ds v0.30.1/go.mod h1:yKjKFm2u7zz3u/MmrOYq1mugsC2trE3diA+WkQrkvvc=
 github.com/aserto-dev/go-grpc v0.8.58 h1:uoNDm6ddJQHR94fIq+v6gHWBZTRTQCvRnNvGxsansrU=
 github.com/aserto-dev/go-grpc v0.8.58/go.mod h1:2FcclMDheTsEvYCY72o+EwTaoO0ti3/it4G6xIlzNIM=
 github.com/aserto-dev/go-http-metrics v0.10.1-20221024-1 h1:nONd24V5nyJ0IIw8QE+OKv30YuHOTNbJ4FsvczLaM8o=

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,8 @@ github.com/aserto-dev/go-decision-logs v0.0.4 h1:beu/mhqZ92ovhSIPOv2f4q0Ci7HWNLl
 github.com/aserto-dev/go-decision-logs v0.0.4/go.mod h1:W50DNu4HPCk+iyI39cP3+KBytdrQYVieSPXh9StuRzA=
 github.com/aserto-dev/go-directory v0.30.2 h1:cUkvzma8paV2YFaCIvjfy1a9DMNCx5qV3EjcLo68RuA=
 github.com/aserto-dev/go-directory v0.30.2/go.mod h1:jHn6ckERuci6nWz9vCzAbYoF2UnbOwEzl++sA1L3nyc=
-github.com/aserto-dev/go-directory-cli v0.30.0 h1:TNQSza1MjDnZJDqqhFj2V4lK16Fm0YQawRW+Jf7R5zg=
-github.com/aserto-dev/go-directory-cli v0.30.0/go.mod h1:WrKLhSCksEs0hG2CMaItu6HsAbQMAq00Bq6Kqw5WkcI=
+github.com/aserto-dev/go-directory-cli v0.30.1-0.20231105222812-42a7b4f12a85 h1:JpC1cCNZKCBPcb6WeSZtXgXZA5IUtGQXbAWDW+Fy8Xg=
+github.com/aserto-dev/go-directory-cli v0.30.1-0.20231105222812-42a7b4f12a85/go.mod h1:EvTAQdfREB8Wq5aRJxk3krkBz6/4LUwJjfbc0MjVUl8=
 github.com/aserto-dev/go-edge-ds v0.30.0 h1:2o1ixUEDEQMEj/5Tk6HcXgirXKhi9GoG470YO4n6eDY=
 github.com/aserto-dev/go-edge-ds v0.30.0/go.mod h1:yKjKFm2u7zz3u/MmrOYq1mugsC2trE3diA+WkQrkvvc=
 github.com/aserto-dev/go-grpc v0.8.58 h1:uoNDm6ddJQHR94fIq+v6gHWBZTRTQCvRnNvGxsansrU=

--- a/pkg/cli/cmd/backup.go
+++ b/pkg/cli/cmd/backup.go
@@ -10,7 +10,8 @@ import (
 )
 
 type BackupCmd struct {
-	File string `arg:""  default:"backup.tar.gz" help:"absolute file path to make backup to"`
+	File   string        `arg:""  default:"backup.tar.gz" help:"absolute file path to make backup to"`
+	Format FormatVersion `flag:"" short:"f" enum:"3,2" name:"format" default:"3" help:"format of json data"`
 	clients.Config
 }
 
@@ -35,5 +36,9 @@ func (cmd *BackupCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	color.Green(">>> backup to %s", cmd.File)
-	return dirClient.Backup(c.Context, cmd.File)
+
+	if cmd.Format == V2 {
+		return dirClient.V2.Backup(c.Context, cmd.File)
+	}
+	return dirClient.V3.Backup(c.Context, cmd.File)
 }

--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -12,14 +12,21 @@ import (
 
 var ErrNotRunning = errors.New("topaz is not running, use 'topaz start' or 'topaz run' to start")
 
+type FormatVersion int
+
+const (
+	V2 FormatVersion = 2
+	V3 FormatVersion = 3
+)
+
 type CLI struct {
 	Start     StartCmd     `cmd:"" help:"start topaz in daemon mode"`
 	Stop      StopCmd      `cmd:"" help:"stop topaz instance"`
 	Status    StatusCmd    `cmd:"" help:"status of topaz daemon process"`
 	Run       RunCmd       `cmd:"" help:"run topaz in console mode"`
 	Manifest  ManifestCmd  `cmd:"" help:"manifest commands"`
-	Load      LoadCmd      `cmd:"" help:"load manifest from file"`
-	Save      SaveCmd      `cmd:"" help:"save manifest to file"`
+	Load      LoadCmd      `cmd:"" help:"load manifest from file (DEPRECATED)"`
+	Save      SaveCmd      `cmd:"" help:"save manifest to file  (DEPRECATED)"`
 	Import    ImportCmd    `cmd:"" help:"import directory objects"`
 	Export    ExportCmd    `cmd:"" help:"export directory objects"`
 	Backup    BackupCmd    `cmd:"" help:"backup directory data"`
@@ -31,7 +38,7 @@ type CLI struct {
 	Uninstall UninstallCmd `cmd:"" help:"uninstall topaz container"`
 	Version   VersionCmd   `cmd:"" help:"version information"`
 	Console   ConsoleCmd   `cmd:"" help:"opens the console in the browser"`
-	NoCheck   bool         `name:"no-check" env:"TOPAZ_NO_CHECK" help:"disable local container status check"`
+	NoCheck   bool         `name:"no-check" short:"N" env:"TOPAZ_NO_CHECK" help:"disable local container status check"`
 }
 
 type VersionCmd struct{}

--- a/pkg/cli/cmd/exporter.go
+++ b/pkg/cli/cmd/exporter.go
@@ -10,7 +10,8 @@ import (
 )
 
 type ExportCmd struct {
-	Directory string `short:"d" required:"" help:"directory to write .json data"`
+	Directory string        `short:"d" required:"" help:"directory to write .json data"`
+	Format    FormatVersion `flag:"" short:"f" enum:"3,2" name:"format" default:"3" help:"format of json data"`
 	clients.Config
 }
 
@@ -30,5 +31,8 @@ func (cmd *ExportCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
-	return dirClient.Export(c.Context, objectsFile, relationsFile)
+	if cmd.Format == V2 {
+		return dirClient.V2.Export(c.Context, objectsFile, relationsFile)
+	}
+	return dirClient.V3.Export(c.Context, objectsFile, relationsFile)
 }

--- a/pkg/cli/cmd/importer.go
+++ b/pkg/cli/cmd/importer.go
@@ -10,7 +10,8 @@ import (
 )
 
 type ImportCmd struct {
-	Directory string `short:"d" required:"" help:"directory containing .json data"`
+	Directory string        `short:"d" required:"" help:"directory containing .json data"`
+	Format    FormatVersion `flag:"" short:"f" enum:"3,2" name:"format" default:"3" help:"format of json data"`
 	clients.Config
 }
 
@@ -32,5 +33,8 @@ func (cmd *ImportCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
-	return dirClient.Import(c.Context, files)
+	if cmd.Format == V2 {
+		return dirClient.V2.Import(c.Context, files)
+	}
+	return dirClient.V3.Import(c.Context, files)
 }

--- a/pkg/cli/cmd/manifest.go
+++ b/pkg/cli/cmd/manifest.go
@@ -43,7 +43,7 @@ func (cmd *GetManifestCmd) Run(c *cc.CommonCtx) error {
 
 	color.Green(">>> get manifest to %s", cmd.Path)
 
-	r, err := dirClient.GetManifest(c.Context)
+	r, err := dirClient.V3.GetManifest(c.Context)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (cmd *SetManifestCmd) Run(c *cc.CommonCtx) error {
 
 	color.Green(">>> set manifest from %s", cmd.Path)
 
-	return dirClient.SetManifest(c.Context, r)
+	return dirClient.V3.SetManifest(c.Context, r)
 }
 
 func (cmd *DeleteManifestCmd) Run(c *cc.CommonCtx) error {
@@ -96,5 +96,5 @@ func (cmd *DeleteManifestCmd) Run(c *cc.CommonCtx) error {
 
 	color.Green(">>> delete manifest")
 
-	return dirClient.DeleteManifest(c.Context)
+	return dirClient.V3.DeleteManifest(c.Context)
 }

--- a/pkg/cli/cmd/restore.go
+++ b/pkg/cli/cmd/restore.go
@@ -11,7 +11,8 @@ import (
 )
 
 type RestoreCmd struct {
-	File string `arg:""  default:"backup.tar.gz" help:"absolute file path to local backup tarball"`
+	File   string        `arg:""  default:"backup.tar.gz" help:"absolute file path to local backup tarball"`
+	Format FormatVersion `flag:"" short:"f" enum:"3,2" name:"format" default:"3" help:"format of json data"`
 	clients.Config
 }
 
@@ -36,5 +37,8 @@ func (cmd *RestoreCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	color.Green(">>> restore from %s", cmd.File)
-	return dirClient.Restore(c.Context, cmd.File)
+	if cmd.Format == V2 {
+		return dirClient.V2.Restore(c.Context, cmd.File)
+	}
+	return dirClient.V3.Restore(c.Context, cmd.File)
 }

--- a/pkg/cli/cmd/test.go
+++ b/pkg/cli/cmd/test.go
@@ -14,7 +14,8 @@ import (
 	dsr2 "github.com/aserto-dev/go-directory/aserto/directory/reader/v2"
 	dsr3 "github.com/aserto-dev/go-directory/aserto/directory/reader/v3"
 
-	"github.com/aserto-dev/go-directory-cli/client"
+	v2 "github.com/aserto-dev/go-directory-cli/client/v2"
+	client "github.com/aserto-dev/go-directory-cli/client/v3"
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/clients"
 
@@ -117,15 +118,15 @@ func (cmd *TestExecCmd) Run(c *cc.CommonCtx) error {
 
 		switch {
 		case checkType == Check && reqVersion == 3:
-			result = checkV3(c.Context, dsc, msg.Fields[checkTypeMapStr[checkType]])
+			result = checkV3(c.Context, dsc.V3, msg.Fields[checkTypeMapStr[checkType]])
 		case checkType == CheckPermission && reqVersion == 3:
-			result = checkPermissionV3(c.Context, dsc, msg.Fields[checkTypeMapStr[checkType]])
+			result = checkPermissionV3(c.Context, dsc.V3, msg.Fields[checkTypeMapStr[checkType]])
 		case checkType == CheckRelation && reqVersion == 3:
-			result = checkRelationV3(c.Context, dsc, msg.Fields[checkTypeMapStr[checkType]])
+			result = checkRelationV3(c.Context, dsc.V3, msg.Fields[checkTypeMapStr[checkType]])
 		case checkType == CheckPermission && reqVersion == 2:
-			result = checkPermissionV2(c.Context, dsc, msg.Fields[checkTypeMapStr[checkType]])
+			result = checkPermissionV2(c.Context, dsc.V2, msg.Fields[checkTypeMapStr[checkType]])
 		case checkType == CheckRelation && reqVersion == 2:
-			result = checkRelationV2(c.Context, dsc, msg.Fields[checkTypeMapStr[checkType]])
+			result = checkRelationV2(c.Context, dsc.V2, msg.Fields[checkTypeMapStr[checkType]])
 		case checkType == CheckDecision:
 			result = checkDecisionV2(c.Context, azc, msg.Fields[checkTypeMapStr[checkType]])
 		}
@@ -308,7 +309,7 @@ func checkRelationV3(ctx context.Context, c *client.Client, msg *structpb.Value)
 	}
 }
 
-func checkPermissionV2(ctx context.Context, c *client.Client, msg *structpb.Value) *checkResult {
+func checkPermissionV2(ctx context.Context, c *v2.Client, msg *structpb.Value) *checkResult {
 	var req dsr2.CheckPermissionRequest
 	if err := unmarshalReq(msg, &req); err != nil {
 		return &checkResult{Err: err}
@@ -316,7 +317,7 @@ func checkPermissionV2(ctx context.Context, c *client.Client, msg *structpb.Valu
 
 	start := time.Now()
 
-	resp, err := c.Reader2.CheckPermission(ctx, &req)
+	resp, err := c.Reader.CheckPermission(ctx, &req)
 
 	duration := time.Since(start)
 
@@ -328,7 +329,7 @@ func checkPermissionV2(ctx context.Context, c *client.Client, msg *structpb.Valu
 	}
 }
 
-func checkRelationV2(ctx context.Context, c *client.Client, msg *structpb.Value) *checkResult {
+func checkRelationV2(ctx context.Context, c *v2.Client, msg *structpb.Value) *checkResult {
 	var req dsr2.CheckRelationRequest
 	if err := unmarshalReq(msg, &req); err != nil {
 		return &checkResult{Err: err}
@@ -336,7 +337,7 @@ func checkRelationV2(ctx context.Context, c *client.Client, msg *structpb.Value)
 
 	start := time.Now()
 
-	resp, err := c.Reader2.CheckRelation(ctx, &req)
+	resp, err := c.Reader.CheckRelation(ctx, &req)
 
 	duration := time.Since(start)
 


### PR DESCRIPTION
This PR adds the --format=2 or -f 2 to commands that support v2 message formats:
* backup
* restore
* import
* export