### PR TITLE
update simple-rbac template policy instance name

### DIFF
--- a/assets/simple-rbac.json
+++ b/assets/simple-rbac.json
@@ -4,7 +4,7 @@
     "assets": {
         "manifest": "/assets/templates/simple-rbac/manifest.yaml",
         "policy": {
-            "name": "default",
+            "name": "simple-rbac",
             "resource": "ghcr.io/aserto-policies/policy-rebac:latest"
         },
         "idp_data": [


### PR DESCRIPTION
We have agreed that each template will have its own policy instance name. 

This PR updates the `simple-rbac` template to use that name for the policy instance name (instead of `default`).
