### PR TITLE
fix builtin not found err handling

### DIFF
--- a/builtins/edge/ds/identity.go
+++ b/builtins/edge/ds/identity.go
@@ -1,9 +1,10 @@
 package ds
 
 import (
-	"github.com/aserto-dev/go-authorizer/pkg/aerr"
 	"github.com/aserto-dev/topaz/directory"
 	"github.com/aserto-dev/topaz/resolvers"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
@@ -61,10 +62,10 @@ func RegisterIdentity(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 
 			user, err := directory.GetIdentityV2(bctx.Context, client, args.ID)
 			switch {
-			case errors.Is(err, aerr.ErrDirectoryObjectNotFound):
-				return nil, err
-			case err != nil:
+			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
+				return ast.NullTerm(), err
+			case err != nil:
 				return nil, err
 			default:
 				return ast.StringTerm(user.Id), nil

--- a/builtins/edge/ds/object.go
+++ b/builtins/edge/ds/object.go
@@ -87,11 +87,12 @@ func RegisterObject(logger *zerolog.Logger, fnName string, dr resolvers.Director
 			}
 
 			resp, err := client.GetObject(bctx.Context, req)
-			if err != nil {
+			switch {
+			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
-				if status.Code(err) != codes.NotFound {
-					return nil, err
-				}
+				return ast.NullTerm(), err
+			case err != nil:
+				return nil, err
 			}
 
 			buf := new(bytes.Buffer)

--- a/builtins/edge/ds/relation.go
+++ b/builtins/edge/ds/relation.go
@@ -108,11 +108,12 @@ func RegisterRelation(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 			}
 
 			resp, err := client.GetRelation(bctx.Context, &args)
-			if err != nil {
+			switch {
+			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
-				if status.Code(err) != codes.NotFound {
-					return nil, err
-				}
+				return ast.NullTerm(), err
+			case err != nil:
+				return nil, err
 			}
 
 			buf := new(bytes.Buffer)

--- a/builtins/edge/ds/user.go
+++ b/builtins/edge/ds/user.go
@@ -73,11 +73,12 @@ func RegisterUser(logger *zerolog.Logger, fnName string, dr resolvers.DirectoryR
 				ObjectId:      args.ID,
 				WithRelations: false,
 			})
-			if err != nil {
+			switch {
+			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
-				if status.Code(err) != codes.NotFound {
-					return nil, err
-				}
+				return ast.NullTerm(), err
+			case err != nil:
+				return nil, err
 			}
 
 			buf := new(bytes.Buffer)


### PR DESCRIPTION
Fix builtins that return singleton results when gRPC is a NOT_FOUND error, return an `ast.NullTerm` instead of an error.
The error is returned in the trace fail notes