### PR TITLE
Fix buildins when NotFound error

### DIFF
--- a/builtins/edge/ds/identity.go
+++ b/builtins/edge/ds/identity.go
@@ -64,7 +64,11 @@ func RegisterIdentity(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 			switch {
 			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
-				return ast.NullTerm(), err
+				astVal, err := ast.InterfaceToValue(map[string]any{})
+				if err != nil {
+					return nil, err
+				}
+				return ast.NewTerm(astVal), nil
 			case err != nil:
 				return nil, err
 			default:

--- a/builtins/edge/ds/object.go
+++ b/builtins/edge/ds/object.go
@@ -90,7 +90,11 @@ func RegisterObject(logger *zerolog.Logger, fnName string, dr resolvers.Director
 			switch {
 			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
-				return ast.NullTerm(), err
+				astVal, err := ast.InterfaceToValue(map[string]any{})
+				if err != nil {
+					return nil, err
+				}
+				return ast.NewTerm(astVal), nil
 			case err != nil:
 				return nil, err
 			}

--- a/builtins/edge/ds/relation.go
+++ b/builtins/edge/ds/relation.go
@@ -111,7 +111,11 @@ func RegisterRelation(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 			switch {
 			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
-				return ast.NullTerm(), err
+				astVal, err := ast.InterfaceToValue(map[string]any{})
+				if err != nil {
+					return nil, err
+				}
+				return ast.NewTerm(astVal), nil
 			case err != nil:
 				return nil, err
 			}

--- a/builtins/edge/ds/user.go
+++ b/builtins/edge/ds/user.go
@@ -76,7 +76,11 @@ func RegisterUser(logger *zerolog.Logger, fnName string, dr resolvers.DirectoryR
 			switch {
 			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)
-				return ast.NullTerm(), err
+				astVal, err := ast.InterfaceToValue(map[string]any{})
+				if err != nil {
+					return nil, err
+				}
+				return ast.NewTerm(astVal), nil
 			case err != nil:
 				return nil, err
 			}


### PR DESCRIPTION
Because an error was returned the policy that was using the result of relation was undefined. Also we should use an empty map rather than ast.NullTerm for the response when the NotFound error is encounter to better emulate an empty response from directory. 