### PR TITLE
grpc health probe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opencensus.io v0.24.0
 	golang.org/x/sync v0.5.0
-	google.golang.org/grpc v1.60.0
+	google.golang.org/grpc v1.60.1
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1462,8 +1462,8 @@ google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCD
 google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
-google.golang.org/grpc v1.60.0 h1:6FQAR0kM31P6MRdeluor2w2gPaS4SVNrD/DNTxrQ15k=
-google.golang.org/grpc v1.60.0/go.mod h1:OlCHIeLYqSSsLi6i49B5QGdzaMZK9+M7LXN2FKz4eGM=
+google.golang.org/grpc v1.60.1 h1:26+wFr+cNqSGFcOXcabYC0lUVJVRa2Sb2ortSK7VrEU=
+google.golang.org/grpc v1.60.1/go.mod h1:OlCHIeLYqSSsLi6i49B5QGdzaMZK9+M7LXN2FKz4eGM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/cli/cmd/template.go
+++ b/pkg/cli/cmd/template.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -412,16 +411,6 @@ func max(rhs, lhs int) int {
 		return lhs
 	}
 	return rhs
-}
-
-func isServing2() bool {
-	cmd := exec.Command("grpc-health-probe", "-addr=localhost:9494", "-connect-timeout=30s", "-rpc-timeout=30s")
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	fmt.Println(string(out))
-	return true
 }
 
 func getTopazDir() (string, error) {

--- a/pkg/cli/cmd/template.go
+++ b/pkg/cli/cmd/template.go
@@ -418,7 +418,7 @@ func getTopazDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(homeDir, ".config", "topaz"), nil
+	return filepath.Clean(path.Join(homeDir, ".config", "topaz")), nil
 }
 
 // isServing adopted from grpc-health-probe cli implementation https://github.com/grpc-ecosystem/grpc-health-probe/blob/master/main.go.
@@ -428,8 +428,8 @@ func isServing() bool {
 	rpcTimeout := time.Second * 30
 
 	bCtx := context.Background()
-	dialCtx, cancel := context.WithTimeout(bCtx, connTimeout)
-	defer cancel()
+	dialCtx, dialCancel := context.WithTimeout(bCtx, connTimeout)
+	defer dialCancel()
 
 	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/pkg/cli/cmd/template.go
+++ b/pkg/cli/cmd/template.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,10 +12,14 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aserto-dev/go-directory/pkg/derr"
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/clients"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 const (
@@ -409,7 +414,7 @@ func max(rhs, lhs int) int {
 	return rhs
 }
 
-func isServing() bool {
+func isServing2() bool {
 	cmd := exec.Command("grpc-health-probe", "-addr=localhost:9494", "-connect-timeout=30s", "-rpc-timeout=30s")
 	out, err := cmd.Output()
 	if err != nil {
@@ -425,4 +430,38 @@ func getTopazDir() (string, error) {
 		return "", err
 	}
 	return path.Join(homeDir, ".config", "topaz"), nil
+}
+
+// isServing adopted from grpc-health-probe cli implementation https://github.com/grpc-ecosystem/grpc-health-probe/blob/master/main.go.
+func isServing() bool {
+	addr := "localhost:9494"
+	connTimeout := time.Second * 30
+	rpcTimeout := time.Second * 30
+
+	bCtx := context.Background()
+	dialCtx, cancel := context.WithTimeout(bCtx, connTimeout)
+	defer cancel()
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	conn, err := grpc.DialContext(dialCtx, addr, dialOpts...)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	rpcCtx, rpcCancel := context.WithTimeout(bCtx, rpcTimeout)
+	defer rpcCancel()
+
+	resp, err := healthpb.NewHealthClient(conn).Check(rpcCtx, &healthpb.HealthCheckRequest{Service: ""})
+	if err != nil {
+		return false
+	}
+
+	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Remove dependency on external `grpc-health-prob` CLI.
Replace with internal implementation by calling the health endpoint directly.
