### PR TITLE
default enable-v2 to false

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,6 @@ logging:
 
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
-  seed_metadata: false
 
 remote_directory:
   address: 0.0.0.0:8282

--- a/docs/config.md
+++ b/docs/config.md
@@ -122,7 +122,7 @@ api:
 The directory section allows setting the configuration for the topaz [local edge directory](https://github.com/aserto-dev/go-edge-ds).
  - *db_path* - string - path to the bbolt database file
  - *request_timeout* - time.Duration - request timeout setting for the bbolt database connection
- - *seed_metadata* - bool - if set to true the bbolt database will be seeded with default metadata
+ - *enable_v2* - boolean - enable directory version 2 services for backward compatibility (default: false)
 
 ### d. Remote
 

--- a/docs/deployments/docker-compose/config/local.yaml
+++ b/docs/deployments/docker-compose/config/local.yaml
@@ -9,7 +9,6 @@ logging:
 
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
-  seed_metadata: true
 
 # remote directory is used to resolve the identity for the authorizer.
 remote_directory:

--- a/docs/deployments/sidecar-deployment/topaz-configmap.yaml
+++ b/docs/deployments/sidecar-deployment/topaz-configmap.yaml
@@ -13,7 +13,6 @@ data:
     
     directory:
       db_path: /db/directory.db
-      seed_metadata: true
     
     # remote directory is used to resolve the identity for the authorizer.
     remote_directory:

--- a/docs/examples/config-local-image.yaml
+++ b/docs/examples/config-local-image.yaml
@@ -10,7 +10,6 @@ logging:
 
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
-  seed_metadata: true
     
 remote_directory:
   address: "localhost:9292"

--- a/docs/examples/config-public-ghcr.yaml
+++ b/docs/examples/config-public-ghcr.yaml
@@ -7,7 +7,6 @@ logging:
 
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
-  seed_metadata: true
     
 api:
   health:

--- a/pkg/cc/config/schema/config.json
+++ b/pkg/cc/config/schema/config.json
@@ -94,9 +94,9 @@
                     "description": "edge directory request timeout in seconds",
                     "default": "5s"
                 },
-                "seed_metadata": {
+                "enable_v2": {
                     "type": "boolean",
-                    "description": "seed edge directory with the default metadata objects",
+                    "description": "enable directory version 2 services for backward compatibility",
                     "default": "false"
                 }
             }

--- a/pkg/cc/config/schema/config.yaml
+++ b/pkg/cc/config/schema/config.yaml
@@ -11,6 +11,7 @@ logging:
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
   request_timeout: "5s"
+  enable_v2: false # enable directory version 2 services for backward compatibility, this defaults to false per topaz 0.31.0
 
 # remote directory is used to resolve the identity for the authorizer.
 remote_directory:

--- a/pkg/cc/config/schema/config.yaml
+++ b/pkg/cc/config/schema/config.yaml
@@ -11,7 +11,6 @@ logging:
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
   request_timeout: "5s"
-  seed_metadata: false
 
 # remote directory is used to resolve the identity for the authorizer.
 remote_directory:

--- a/pkg/cc/config/templates.go
+++ b/pkg/cc/config/templates.go
@@ -58,7 +58,6 @@ logging:
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
   request_timeout: 5s # set as default, 5 secs.
-  seed_metadata: false # deprecated in v3, with the introduction of manifest files, this always defaults to false.
   enable_v2: {{ .EnableDirectoryV2 }} # enable directory version 2 services for backward compatibility, this defaults to false per topaz 0.31.0
 
 # remote directory is used to resolve the identity for the authorizer.

--- a/pkg/cc/config/templates.go
+++ b/pkg/cc/config/templates.go
@@ -59,6 +59,7 @@ directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
   request_timeout: 5s # set as default, 5 secs.
   seed_metadata: false # deprecated in v3, with the introduction of manifest files, this always defaults to false.
+  enable_v2: {{ .EnableDirectoryV2 }} # enable directory version 2 services for backwards compatibility, this defaults to false per topaz 0.31.0
 
 # remote directory is used to resolve the identity for the authorizer.
 remote_directory:

--- a/pkg/cc/config/templates.go
+++ b/pkg/cc/config/templates.go
@@ -59,7 +59,7 @@ directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
   request_timeout: 5s # set as default, 5 secs.
   seed_metadata: false # deprecated in v3, with the introduction of manifest files, this always defaults to false.
-  enable_v2: {{ .EnableDirectoryV2 }} # enable directory version 2 services for backwards compatibility, this defaults to false per topaz 0.31.0
+  enable_v2: {{ .EnableDirectoryV2 }} # enable directory version 2 services for backward compatibility, this defaults to false per topaz 0.31.0
 
 # remote directory is used to resolve the identity for the authorizer.
 remote_directory:

--- a/pkg/cli/cmd/configure.go
+++ b/pkg/cli/cmd/configure.go
@@ -18,7 +18,7 @@ type ConfigureCmd struct {
 	Stdout            bool   `short:"p" help:"generated configuration is printed to stdout but not saved"`
 	EdgeDirectory     bool   `short:"d" help:"enable edge directory" default:"false"`
 	Force             bool   `flag:"" default:"false" short:"f" required:"false" help:"forcefully create configuration"`
-	EnableDirectoryV2 bool   `flag:"" name:"enable-v2" default:"false" help:"enable directory version 2 services for backwards compatibility"`
+	EnableDirectoryV2 bool   `flag:"" name:"enable-v2" default:"false" help:"enable directory version 2 services for backward compatibility"`
 }
 
 func (cmd ConfigureCmd) Run(c *cc.CommonCtx) error {

--- a/pkg/cli/cmd/configure.go
+++ b/pkg/cli/cmd/configure.go
@@ -17,7 +17,7 @@ type ConfigureCmd struct {
 	Resource          string `short:"r" help:"resource url"`
 	Stdout            bool   `short:"p" help:"generated configuration is printed to stdout but not saved"`
 	EdgeDirectory     bool   `short:"d" help:"enable edge directory" default:"false"`
-	Force             bool   `flag:"" default:"false" short:"f" required:"false" help:"forcefully create configuration"`
+	Force             bool   `flag:"" default:"false" short:"f" help:"forcefully create configuration"`
 	EnableDirectoryV2 bool   `flag:"" name:"enable-v2" default:"false" help:"enable directory version 2 services for backward compatibility"`
 }
 

--- a/pkg/cli/cmd/configure.go
+++ b/pkg/cli/cmd/configure.go
@@ -18,7 +18,7 @@ type ConfigureCmd struct {
 	Stdout            bool   `short:"p" help:"generated configuration is printed to stdout but not saved"`
 	EdgeDirectory     bool   `short:"d" help:"enable edge directory" default:"false"`
 	Force             bool   `flag:"" default:"false" short:"f" required:"false" help:"forcefully create configuration"`
-	EnableDirectoryV2 bool   `flag:"" name:"enable-v2" hidden:"" default:"true" help:"enable directory version 2 services for backwards compatibility"`
+	EnableDirectoryV2 bool   `flag:"" name:"enable-v2" default:"false" help:"enable directory version 2 services for backwards compatibility"`
 }
 
 func (cmd ConfigureCmd) Run(c *cc.CommonCtx) error {

--- a/pkg/rapidoc/rapidoc.go
+++ b/pkg/rapidoc/rapidoc.go
@@ -97,7 +97,7 @@ const (
 	show-header = "true"
 	allow-spec-url-load = "false"
 	allow-spec-file-load = "false"
-	allow-server-selection = "false"
+	allow-server-selection = "true"
   >
   <div slot="logo" style="display: flex; align-items: center; justify-content: center;">
   	<img src = "https://www.aserto.com/images/Aserto-logo-color-120px.png" style="width:120px; margin-right: 40px"> <span style="color:#fff"></span>

--- a/pkg/testing/assets/config-local.yaml
+++ b/pkg/testing/assets/config-local.yaml
@@ -8,7 +8,6 @@ logging:
 
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
-  seed_metadata: true
 
 # remote directory is used to resolve the identity for the authorizer.
 remote_directory:

--- a/pkg/testing/assets/config-online.yaml
+++ b/pkg/testing/assets/config-online.yaml
@@ -8,7 +8,6 @@ logging:
 
 directory:
   db_path: ${TOPAZ_DIR}/db/directory.db
-  seed_metadata: true
 
 # remote directory is used to resolve the identity for the authorizer.
 remote_directory:


### PR DESCRIPTION
By default, starting with `topaz 0.31.0` enable only the v3 directory services, disabling the v2 services.

### Why turn off v2 directory service
The new manifest expects support for `subject relations`, which are not supported by the v2 directory services having v2 directory services enabled could be a source of confusion.

SDKs will have to require the v3 service in order to enable using subject-relation usage.

### What changed:
`topaz configure` exposes a new option named ` --enable-v2` to turn the v2 directory services on.

```
topaz configure --help
Usage: topaz configure

configure topaz service

Flags:
  -h, --help                         Show context-sensitive help.
  -N, --no-check                     disable local container status check ($TOPAZ_NO_CHECK)

  -n, --policy-name=STRING           policy name
  -l, --local-policy-image=STRING    local policy image name
  -r, --resource=STRING              resource url
  -p, --stdout                       generated configuration is printed to stdout but not saved
  -d, --edge-directory               enable edge directory
  -f, --force                        forcefully create configuration
      --enable-v2                    enable directory version 2 services for backward compatibility
```

A new configuration value, `enable_v2` is exposed in the `directory` configuration block

```
directory:
  db_path: ${TOPAZ_DIR}/db/directory.db
  request_timeout: 5s # set as default, 5 secs.
  enable_v2: false # enable directory version 2 services for backward compatibility, this defaults to false per topaz 0.31.0
```