### PR TITLE
add option for a single /data volume and support TOPAZ_DIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ WORKDIR /app
 
 COPY dist/topaz*_linux_amd64_v1/topaz* /app/
 
-ENTRYPOINT ["./topazd"]
-CMD ["run", "-c", "/config/config.yaml"]
+ENV TOPAZ_DIR=/config
+
+ENTRYPOINT ["sh", "-c", "./topazd"]
+CMD ["run", "-c", "${TOPAZ_DIR}/config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM alpine
 
 RUN apk add --no-cache bash tzdata
 
-RUN mkdir /config && \
+RUN mkdir /data && \
+    mkdir /config && \
     mkdir /certs && \
     mkdir /db && \
     mkdir /decisions
-VOLUME ["/config", "/certs", "/db", "/decisions"]
+VOLUME ["/data", "/config", "/certs", "/db", "/decisions"]
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ VOLUME ["/data", "/config", "/certs", "/db", "/decisions"]
 
 WORKDIR /app
 
-COPY dist/topaz*_linux_amd64_v1/topaz* /app/
+COPY docker-entrypoint.sh dist/topaz*_linux_amd64_v1/topaz* /app/
 
 ENV TOPAZ_DIR=/config
 
-ENTRYPOINT ["sh", "-c", "./topazd"]
-CMD ["run", "-c", "${TOPAZ_DIR}/config.yaml"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["run", "-c", "@@TOPAZ_DIR@@/config.yaml"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -13,5 +13,8 @@ WORKDIR /app
 
 COPY topaz* /app/
 
-ENTRYPOINT ["./topazd"]
-CMD ["run", "-c", "/config/config.yaml"]
+ENV TOPAZ_DIR=/config
+
+ENTRYPOINT ["sh", "-c", "./topazd"]
+CMD ["run", "-c", "${TOPAZ_DIR}/config.yaml"]
+

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -2,11 +2,12 @@ FROM alpine
 
 RUN apk add --no-cache bash tzdata
 
-RUN mkdir /config && \
+RUN mkdir /data && \
+    mkdir /config && \
     mkdir /certs && \
     mkdir /db && \
     mkdir /decisions
-VOLUME ["/config", "/certs", "/db", "/decisions"]
+VOLUME ["/data", "/config", "/certs", "/db", "/decisions"]
 
 WORKDIR /app
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -11,10 +11,9 @@ VOLUME ["/data", "/config", "/certs", "/db", "/decisions"]
 
 WORKDIR /app
 
-COPY topaz* /app/
+COPY docker-entrypoint.sh topaz* /app/
 
 ENV TOPAZ_DIR=/config
 
-ENTRYPOINT ["sh", "-c", "./topazd"]
-CMD ["run", "-c", "${TOPAZ_DIR}/config.yaml"]
-
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["run", "-c", "@@TOPAZ_DIR@@/config.yaml"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+COMMAND=$(sed 's~@@TOPAZ_DIR@@~'${TOPAZ_DIR}'~' <<<"$@")
+./topazd $COMMAND


### PR DESCRIPTION
allow config.yaml path to be overridden by TOPAZ_DIR

and add /data to give folks a named option to use a single volume for config, certs, and db.
practically speaking, many customers are going to need to run topaz with a single data volume rather than 4

in ECS, it is only possible to mount one EBS volume per task
in AKS, there's often a limit of 8 volumes per HOST, and it's hard to justify topaz using 4 of those slots