### PR TITLE
use testing t.TempDir() instead of os.TempDir()

### DIFF
--- a/pkg/app/tests/manifest/manifest_test.go
+++ b/pkg/app/tests/manifest/manifest_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestManifest(t *testing.T) {
-	tempDir := os.TempDir()
+	tempDir := t.TempDir()
 	harness := atesting.SetupOnline(t, func(cfg *config.Config) {
 		cfg.Edge.DBPath = path.Join(tempDir, "test.db")
 	})

--- a/pkg/testing/assets.go
+++ b/pkg/testing/assets.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"testing"
 
 	"github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/pkg/errors"
@@ -20,9 +21,11 @@ func AssetsDir() string {
 
 // AssetAcmeDBFilePath returns the path of the test contoso EDS database file.
 func AssetAcmeDBFilePath() string {
+
 	const filename = "eds-acmecorp.db"
+	t := testing.T{}
 	srcFile := filepath.Join(AssetsDir(), filename)
-	dstFile := filepath.Join(os.TempDir(), filename)
+	dstFile := filepath.Join(t.TempDir(), filename)
 
 	if err := fcopy(srcFile, dstFile, true); err != nil {
 		panic(err)


### PR DESCRIPTION
Use the testing package t.TempDir() instead of the os.TempDir() to prevent using the same temp directory between test runs, leading to incorrect results.