### PR TITLE
hide deprecated load & save commands

### DIFF
--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -37,8 +37,8 @@ type CLI struct {
 	Certs     CertsCmd     `cmd:"" help:"cert commands"`
 	Update    UpdateCmd    `cmd:"" help:"update topaz container version"`
 	Uninstall UninstallCmd `cmd:"" help:"uninstall topaz container"`
-	Load      LoadCmd      `cmd:"" help:"load manifest from file (DEPRECATED)"`
-	Save      SaveCmd      `cmd:"" help:"save manifest to file  (DEPRECATED)"`
+	Load      LoadCmd      `cmd:"" help:"load manifest from file (DEPRECATED)" hidden:""`
+	Save      SaveCmd      `cmd:"" help:"save manifest to file  (DEPRECATED)" hidden:""`
 	Version   VersionCmd   `cmd:"" help:"version information"`
 	NoCheck   bool         `name:"no-check" short:"N" env:"TOPAZ_NO_CHECK" help:"disable local container status check"`
 }


### PR DESCRIPTION
Hide the `load` and `save` commands, which are deprecated by `manifest set` and `manifest get`

```
topaz load
topaz: error: The "topaz load" command has been deprecated, see "topaz manifest set".
```

```
topaz save
topaz: error: The "topaz save" command has been deprecated, see "topaz manifest get".
```