### PR TITLE
templates verify cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/alecthomas/kong v0.8.1
 	github.com/aserto-dev/aserto-grpc v0.2.2
 	github.com/aserto-dev/aserto-management v0.9.4
+	github.com/aserto-dev/azm v0.1.1
 	github.com/aserto-dev/certs v0.0.5
 	github.com/aserto-dev/clui v0.8.3
 	github.com/aserto-dev/errors v0.0.6
@@ -68,7 +69,6 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
-	github.com/aserto-dev/azm v0.1.1 // indirect
 	github.com/aserto-dev/go-decision-logs v0.0.4 // indirect
 	github.com/aserto-dev/go-http-metrics v0.10.1-20221024-1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/pkg/cli/cmd/template.go
+++ b/pkg/cli/cmd/template.go
@@ -599,7 +599,9 @@ func (cmd *VerifyTemplateCmd) Run(c *cc.CommonCtx) error {
 			table.WithTableRow(tmplName, absURL, fmt.Sprintf("%t", exists), fmt.Sprintf("%t", parsed), errStr)
 		}
 		{
-			assets := append(tmpl.Assets.Assertions, tmpl.Assets.IdentityData...)
+			assets := []string{}
+			assets = append(assets, tmpl.Assets.Assertions...)
+			assets = append(assets, tmpl.Assets.IdentityData...)
 			assets = append(assets, tmpl.Assets.DomainData...)
 
 			for _, assetURL := range assets {
@@ -619,7 +621,7 @@ func (cmd *VerifyTemplateCmd) Run(c *cc.CommonCtx) error {
 	return nil
 }
 
-func validateManifest(absURL string) (exists bool, parsed bool, err error) {
+func validateManifest(absURL string) (exists, parsed bool, err error) {
 	b, err := getBytes(absURL)
 	if err != nil {
 		return false, false, err
@@ -632,7 +634,7 @@ func validateManifest(absURL string) (exists bool, parsed bool, err error) {
 	return true, true, nil
 }
 
-func validateJSON(absURL string) (exists bool, parsed bool, err error) {
+func validateJSON(absURL string) (exists, parsed bool, err error) {
 	b, err := getBytes(absURL)
 	if err != nil {
 		return false, false, err

--- a/pkg/cli/cmd/template.go
+++ b/pkg/cli/cmd/template.go
@@ -13,11 +13,13 @@ import (
 	"strings"
 	"time"
 
+	v3 "github.com/aserto-dev/azm/v3"
 	"github.com/aserto-dev/go-directory/pkg/derr"
 	"github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/clients"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -26,6 +28,7 @@ import (
 type TemplateCmd struct {
 	List    ListTemplatesCmd   `cmd:"" help:"list template"`
 	Install InstallTemplateCmd `cmd:"" help:"install template"`
+	Verify  VerifyTemplateCmd  `cmd:"" help:"verify template content links" hidden:""`
 }
 
 type ListTemplatesCmd struct {
@@ -33,14 +36,8 @@ type ListTemplatesCmd struct {
 }
 
 func (cmd *ListTemplatesCmd) Run(c *cc.CommonCtx) error {
-	buf, err := getBytes(cmd.TemplatesURL)
+	ctlg, err := getCatalog(cmd.TemplatesURL)
 	if err != nil {
-		return err
-	}
-
-	var ctlg tmplCatalog
-
-	if err := json.Unmarshal(buf, &ctlg); err != nil {
 		return err
 	}
 
@@ -568,4 +565,83 @@ func Retry(timeout, interval time.Duration, f func() error) (err error) {
 			time.Sleep(interval)
 		}
 	}
+}
+
+type VerifyTemplateCmd struct {
+	TemplatesURL string `arg:"" required:"false" default:"https://topaz.sh/assets/templates/templates.json" help:"URL of template catalog"`
+}
+
+func (cmd *VerifyTemplateCmd) Run(c *cc.CommonCtx) error {
+	ctlg, err := getCatalog(cmd.TemplatesURL)
+	if err != nil {
+		return err
+	}
+
+	// limit the amount of noise from the azm parser.
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	table := c.UI.Normal().WithTable("template", "asset", "exists", "parsed", "error")
+	table.WithTableNoAutoWrapText()
+
+	for tmplName := range ctlg {
+
+		tmpl, err := getTemplate(tmplName, cmd.TemplatesURL)
+		if err != nil {
+			return err
+		}
+		{
+			absURL := tmpl.AbsURL(tmpl.Assets.Manifest)
+			exists, parsed, err := validateManifest(absURL)
+			errStr := ""
+			if err != nil {
+				errStr = err.Error()
+			}
+			table.WithTableRow(tmplName, absURL, fmt.Sprintf("%t", exists), fmt.Sprintf("%t", parsed), errStr)
+		}
+		{
+			assets := append(tmpl.Assets.Assertions, tmpl.Assets.IdentityData...)
+			assets = append(assets, tmpl.Assets.DomainData...)
+
+			for _, assetURL := range assets {
+				absURL := tmpl.AbsURL(assetURL)
+				exists, parsed, err := validateJSON(absURL)
+				errStr := ""
+				if err != nil {
+					errStr = err.Error()
+				}
+				table.WithTableRow(tmplName, absURL, fmt.Sprintf("%t", exists), fmt.Sprintf("%t", parsed), errStr)
+			}
+		}
+	}
+
+	table.Do()
+
+	return nil
+}
+
+func validateManifest(absURL string) (exists bool, parsed bool, err error) {
+	b, err := getBytes(absURL)
+	if err != nil {
+		return false, false, err
+	}
+
+	if _, err := v3.Load(bytes.NewReader(b)); err != nil {
+		return true, false, err
+	}
+
+	return true, true, nil
+}
+
+func validateJSON(absURL string) (exists bool, parsed bool, err error) {
+	b, err := getBytes(absURL)
+	if err != nil {
+		return false, false, err
+	}
+
+	var v map[string]interface{}
+	if err := json.NewDecoder(bytes.NewReader(b)).Decode(&v); err != nil {
+		return true, false, err
+	}
+
+	return true, true, nil
 }


### PR DESCRIPTION
This PR adds topaz templates verify [optional URL or file path to templates container file]

Like:
```
topaz templates verify https://deploy-preview-93--topaz-sh.netlify.app/assets/templates/templates.json
```
or
```
topaz templates verify ./assets/templates.json
```
The output:
```
 TEMPLATE      ASSET                                          EXISTS  PARSED  ERROR  
  todo          assets/todo/manifest.yaml                      true    true           
  todo          assets/citadel/citadel_objects.json            true    true           
  todo          assets/citadel/citadel_relations.json          true    true           
  todo          assets/todo/todo_objects.json                  true    true           
  todo          assets/todo/todo_relations.json                true    true           
  simple-rbac   assets/simple-rbac/manifest.yaml               true    true           
  simple-rbac   assets/citadel/citadel_objects.json            true    true           
  simple-rbac   assets/citadel/citadel_relations.json          true    true           
  simple-rbac   assets/simple-rbac/simple-rbac_objects.json    true    true           
  simple-rbac   assets/simple-rbac/simple-rbac_relations.json  true    true           
  gdrive        assets/gdrive/manifest.yaml                    true    true           
  gdrive        assets/gdrive/test/gdrive_assertions.json      true    true           
  gdrive        assets/citadel/citadel_objects.json            true    true           
  gdrive        assets/citadel/citadel_relations.json          true    true           
  gdrive        assets/gdrive/gdrive_objects.json              true    true           
  gdrive        assets/gdrive/gdrive_relations.json            true    true           
  slack         assets/slack/manifest.yaml                     true    true           
  slack         assets/slack/test/slack_assertions.json        true    true           
  slack         assets/citadel/citadel_objects.json            true    true           
  slack         assets/citadel/citadel_relations.json          true    true           
  slack         assets/slack/slack_objects.json                true    true           
  slack         assets/slack/slack_relations.json              true    true           
  github        assets/github/manifest.yaml                    true    true           
  github        assets/github/test/github_assertions.json      true    true           
  github        assets/citadel/citadel_objects.json            true    true           
  github        assets/citadel/citadel_relations.json          true    true           
  github        assets/github/github_objects.json              true    true           
  github        assets/github/github_relations.json            true    true           
  peoplefinder  assets/acmecorp/manifest.yaml                  true    true           
  peoplefinder  assets/acmecorp/acmecorp_objects.json          true    true           
  peoplefinder  assets/acmecorp/acmecorp_relations.json        true    true    
```

The `verify` command checks if the assets in the template definition can be retrieved and parsed. It does not persist anything on disk.
