### PR TITLE
Prevent the `version` field from env var overriding

### DIFF
--- a/pkg/cc/config/loader.go
+++ b/pkg/cc/config/loader.go
@@ -21,13 +21,29 @@ type Loader struct {
 
 var envRegex = regexp.MustCompile(`(?U:\${.*})`)
 
+type replacer struct {
+	r *strings.Replacer
+}
+
+func newReplacer() *replacer {
+	return &replacer{r: strings.NewReplacer(".", "_")}
+}
+
+func (r replacer) Replace(s string) string {
+	if s == "TOPAZ_VERSION" {
+		// Prevent the `version` field from be overridden by env vars.
+		return ""
+	}
+
+	return r.r.Replace(s)
+}
+
 func LoadConfiguration(fileName string) (*Loader, error) {
-	v := viper.New()
+	v := viper.NewWithOptions(viper.EnvKeyReplacer(newReplacer()))
 	v.SetConfigType("yaml")
 	v.AddConfigPath(".")
 	v.SetConfigFile(fileName)
 	v.SetEnvPrefix("TOPAZ")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	// Set defaults
 	v.SetDefault("jwt.acceptable_time_skew_seconds", 5)


### PR DESCRIPTION
Without this change, the TOPAZ_VERSION env var can be set to override the `version` field in config.
That causes two problems:
1. It never makes sense to overwrite the config file format via an environment variable.
2. It prevents users from using the TOPAZ_VERSION env var for other purposes like the actual topaz version to use.