### PR TITLE
upd ci.yaml to use available node 20 actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,12 +32,12 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       -
         name: Build
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -46,7 +46,7 @@ jobs:
           args: build --clean --snapshot --single-target
       -
         name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GO_LANGCI_LINT_VERSION }}
           args: --timeout=30m


### PR DESCRIPTION
Fix gh warnings

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: 

actions/setup-go@v4
goreleaser/goreleaser-action@v4
golangci/golangci-lint-action@v3 
autero1/action-gotestsum@v2.0.0 

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
```

Note there is currently no update for `autero1/action-gotestsum@v2.0.0`