### PR TITLE
Combine `start` and `run` implementations

### DIFF
--- a/pkg/cli/cmd/install.go
+++ b/pkg/cli/cmd/install.go
@@ -23,8 +23,6 @@ func (cmd *InstallCmd) Run(c *cc.CommonCtx) error {
 
 	color.Green(">>> installing topaz...")
 
-	env := map[string]string{}
-
 	args := []string{
 		"pull",
 		"--platform", cmd.ContainerPlatform,
@@ -36,5 +34,5 @@ func (cmd *InstallCmd) Run(c *cc.CommonCtx) error {
 		),
 	}
 
-	return dockerx.DockerWith(env, args...)
+	return dockerx.DockerV(args...)
 }

--- a/pkg/cli/cmd/run.go
+++ b/pkg/cli/cmd/run.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
-	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
-
-	"github.com/fatih/color"
 )
 
 type RunCmd struct {
@@ -12,23 +9,5 @@ type RunCmd struct {
 }
 
 func (cmd *RunCmd) Run(c *cc.CommonCtx) error {
-	if c.CheckRunStatus(cmd.ContainerName, cc.StatusRunning) {
-		return ErrIsRunning
-	}
-
-	color.Green(">>> starting topaz...")
-	cmdX := cmd.StartRunCmd
-	args, err := cmdX.dockerArgs(cc.GetTopazDir(), true)
-	if err != nil {
-		return err
-	}
-
-	cmdArgs := []string{
-		"run",
-		"--config-file", "/config/config.yaml",
-	}
-
-	args = append(args, cmdArgs...)
-
-	return dockerx.DockerWith(cmdX.env(), args...)
+	return cmd.run(c, modeInteractive)
 }

--- a/pkg/cli/cmd/start.go
+++ b/pkg/cli/cmd/start.go
@@ -1,15 +1,7 @@
 package cmd
 
 import (
-	"os"
-	"path"
-
-	"github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
-	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
-	"github.com/pkg/errors"
-
-	"github.com/fatih/color"
 )
 
 type StartCmd struct {
@@ -17,37 +9,5 @@ type StartCmd struct {
 }
 
 func (cmd *StartCmd) Run(c *cc.CommonCtx) error {
-	cmdX := cmd.StartRunCmd
-
-	if c.CheckRunStatus(cmd.ContainerName, cc.StatusRunning) {
-		return ErrIsRunning
-	}
-
-	color.Green(">>> starting topaz...")
-	args, err := cmdX.dockerArgs(cc.GetTopazDir(), false)
-	if err != nil {
-		return err
-	}
-
-	cmdArgs := []string{
-		"run",
-		"--config-file", "/config/config.yaml",
-	}
-
-	args = append(args, cmdArgs...)
-
-	if _, err := os.Stat(path.Join(cc.GetTopazCfgDir(), "config.yaml")); errors.Is(err, os.ErrNotExist) {
-		return errors.Errorf("%s does not exist, please run 'topaz configure'", path.Join(cc.GetTopazCfgDir(), "config.yaml"))
-	}
-
-	generator := config.NewGenerator("config.yaml")
-	if _, err := generator.CreateCertsDir(); err != nil {
-		return err
-	}
-
-	if _, err := generator.CreateDataDir(); err != nil {
-		return err
-	}
-
-	return dockerx.DockerWith(cmdX.env(), args...)
+	return cmd.run(c, modeDaemon)
 }

--- a/pkg/cli/cmd/startrun.go
+++ b/pkg/cli/cmd/startrun.go
@@ -3,12 +3,15 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
 	"github.com/samber/lo"
 )
 
@@ -23,20 +26,66 @@ type StartRunCmd struct {
 	ContainerVersion  string   `optional:"" hidden:"" default:"" env:"CONTAINER_VERSION"`
 }
 
-func (cmd *StartRunCmd) dockerArgs(rootPath string, interactive bool) ([]string, error) {
+type runMode int
+
+const (
+	modeDaemon runMode = iota
+	modeInteractive
+)
+
+func (cmd *StartRunCmd) run(c *cc.CommonCtx, mode runMode) error {
+	if c.CheckRunStatus(cmd.ContainerName, cc.StatusRunning) {
+		return ErrIsRunning
+	}
+
+	cfg, err := config.LoadConfiguration(filepath.Join(cc.GetTopazCfgDir(), "config.yaml"))
+	if err != nil {
+		return err
+	}
+
+	color.Green(">>> starting topaz...")
+	args, err := cmd.dockerArgs(cfg, mode)
+	if err != nil {
+		return err
+	}
+
+	cmdArgs := []string{
+		"run",
+		"--config-file", "/config/config.yaml",
+	}
+
+	args = append(args, cmdArgs...)
+
+	if _, err := os.Stat(path.Join(cc.GetTopazCfgDir(), "config.yaml")); errors.Is(err, os.ErrNotExist) {
+		return errors.Errorf("%s does not exist, please run 'topaz configure'", path.Join(cc.GetTopazCfgDir(), "config.yaml"))
+	}
+
+	generator := config.NewGenerator("config.yaml")
+	if _, err := generator.CreateCertsDir(); err != nil {
+		return err
+	}
+
+	if _, err := generator.CreateDataDir(); err != nil {
+		return err
+	}
+
+	return dockerx.DockerWith(cmd.env(), args...)
+}
+
+func (cmd *StartRunCmd) dockerArgs(cfg *config.Loader, mode runMode) ([]string, error) {
 	cmd.ContainerTag = cc.ContainerVersionTag(cmd.ContainerVersion, cmd.ContainerTag)
 
 	args := []string{
 		"run",
 		"--rm",
 		"--name", cmd.ContainerName,
-		lo.Ternary(interactive, "-ti", "-d"),
+		lo.Ternary(mode == modeInteractive, "-ti", "-d"),
 	}
 
 	policyRoot := dockerx.PolicyRoot()
 	args = append(args, "-v", fmt.Sprintf("%s:/root/.policy:ro", policyRoot))
 
-	volumes, err := getVolumes(rootPath)
+	volumes, err := getVolumes(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +106,7 @@ func (cmd *StartRunCmd) dockerArgs(rootPath string, interactive bool) ([]string,
 		}
 	}
 
-	ports, err := getPorts(rootPath)
+	ports, err := getPorts(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -88,23 +137,17 @@ func (cmd *StartRunCmd) env() map[string]string {
 	}
 }
 
-func getPorts(rootPath string) ([]string, error) {
-	portMap := make(map[string]string)
-	configLoader, err := config.LoadConfiguration(fmt.Sprintf("%s/cfg/config.yaml", rootPath))
+func getPorts(cfg *config.Loader) ([]string, error) {
+	portArray, err := cfg.GetPorts()
 	if err != nil {
 		return nil, err
-	}
-
-	portArray, err := configLoader.GetPorts()
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range portArray {
-		portMap[portArray[i]] = fmt.Sprintf("%s:%s", portArray[i], portArray[i])
 	}
 
 	// ensure unique assignment for each port
+	portMap := lo.Associate(portArray, func(port string) (string, string) {
+		return port, fmt.Sprintf("%s:%s", port, port)
+	})
+
 	var args []string
 	for _, v := range portMap {
 		args = append(args, "-p", v)
@@ -112,31 +155,19 @@ func getPorts(rootPath string) ([]string, error) {
 	return args, nil
 }
 
-func getVolumes(rootPath string) ([]string, error) {
-	volumeMap := make(map[string]string)
-	configPath := fmt.Sprintf("%s/cfg/config.yaml", rootPath)
-	err := os.Setenv("TOPAZ_DIR", cc.GetTopazDir())
+func getVolumes(cfg *config.Loader) ([]string, error) {
+	paths, err := cfg.GetPaths()
 	if err != nil {
 		return nil, err
 	}
 
-	configLoader, err := config.LoadConfiguration(configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	paths, err := configLoader.GetPaths()
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range paths {
-		directory := filepath.Dir(paths[i])
-		volumeMap[directory] = fmt.Sprintf("%s:%s", directory, fmt.Sprintf("/%s", filepath.Base(directory)))
-	}
+	volumeMap := lo.Associate(paths, func(path string) (string, string) {
+		dir := filepath.Dir(path)
+		return dir, fmt.Sprintf("%s:%s", dir, fmt.Sprintf("/%s", filepath.Base(dir)))
+	})
 
 	// manually attach the configuration folder
-	args := []string{"-v", fmt.Sprintf("%s:/config:ro", filepath.Dir(configPath))}
+	args := []string{"-v", fmt.Sprintf("%s:/config:ro", cc.GetTopazCfgDir())}
 	for _, v := range volumeMap {
 		args = append(args, "-v", v)
 	}

--- a/pkg/cli/cmd/startrun.go
+++ b/pkg/cli/cmd/startrun.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
@@ -89,6 +90,22 @@ func (cmd *StartRunCmd) dockerArgs(cfg *config.Loader, mode runMode) ([]string, 
 		return nil, err
 	}
 	args = append(args, volumes...)
+
+	for i := range volumes {
+		if volumes[i] == "-v" {
+			continue
+		}
+		destination := strings.Split(volumes[i], ":")
+		mountedPath := fmt.Sprintf("/%s", filepath.Base(destination[1])) // last value from split.
+		switch {
+		case strings.Contains(volumes[i], "certs"):
+			cmd.Env = append(cmd.Env, fmt.Sprintf("TOPAZ_CERTS_DIR=%s", mountedPath))
+		case strings.Contains(volumes[i], "db"):
+			cmd.Env = append(cmd.Env, fmt.Sprintf("TOPAZ_DB_DIR=%s", mountedPath))
+		case strings.Contains(volumes[i], "cfg"):
+			cmd.Env = append(cmd.Env, fmt.Sprintf("TOPAZ_CFG_DIR=%s", mountedPath))
+		}
+	}
 
 	ports, err := getPorts(cfg)
 	if err != nil {

--- a/pkg/cli/cmd/stop.go
+++ b/pkg/cli/cmd/stop.go
@@ -11,6 +11,7 @@ type StopCmd struct {
 }
 
 func (cmd *StopCmd) Run(c *cc.CommonCtx) error {
+	c.NoCheck = false // enforce that Stop does not bypass CheckRunStatus() to short-circuit.
 	if c.CheckRunStatus(cmd.ContainerName, cc.StatusNotRunning) {
 		return nil
 	}

--- a/pkg/cli/cmd/uninstall.go
+++ b/pkg/cli/cmd/uninstall.go
@@ -28,8 +28,6 @@ func (cmd *UninstallCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
-	env := map[string]string{}
-
 	args := []string{
 		"images",
 		cc.Container(
@@ -41,7 +39,7 @@ func (cmd *UninstallCmd) Run(c *cc.CommonCtx) error {
 		"-q",
 	}
 
-	str, err := dockerx.DockerWithOut(env, args...)
+	str, err := dockerx.DockerOut(args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/update.go
+++ b/pkg/cli/cmd/update.go
@@ -19,8 +19,6 @@ func (cmd *UpdateCmd) Run(c *cc.CommonCtx) error {
 
 	color.Green(">>> updating topaz...")
 
-	env := map[string]string{}
-
 	args := []string{
 		"pull",
 		"--platform", cmd.ContainerPlatform,
@@ -32,5 +30,5 @@ func (cmd *UpdateCmd) Run(c *cc.CommonCtx) error {
 		),
 	}
 
-	return dockerx.DockerWith(env, args...)
+	return dockerx.DockerV(args...)
 }

--- a/pkg/cli/cmd/version.go
+++ b/pkg/cli/cmd/version.go
@@ -30,8 +30,6 @@ func (cmd *VersionCmd) Run(c *cc.CommonCtx) error {
 		return nil
 	}
 
-	env := map[string]string{}
-
 	// default command
 	// docker run -ti --rm --name topazd-version --platform linux/arm64 ghcr.io/aserto-dev/topaz:latest version
 	args := []string{
@@ -49,7 +47,7 @@ func (cmd *VersionCmd) Run(c *cc.CommonCtx) error {
 		"version",
 	}
 
-	result, err := dockerx.DockerWithOut(env, args...)
+	result, err := dockerx.DockerOut(args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/dockerx/docker.go
+++ b/pkg/cli/dockerx/docker.go
@@ -20,12 +20,8 @@ var (
 	DockerOut = sh.OutCmd(docker)
 )
 
-func DockerWith(env map[string]string, args ...string) error {
-	return sh.RunWithV(env, docker, args...)
-}
-
-func DockerWithOut(env map[string]string, args ...string) (string, error) {
-	return sh.OutputWith(env, docker, args...)
+func DockerV(args ...string) error {
+	return sh.RunV(docker, args...)
 }
 
 func IsRunning(name string) (bool, error) {


### PR DESCRIPTION
The code in `topaz run` and `topaz start` is already starting to diverge again.
This PR refactors it to make sure the two implementations remain in sync.

It also tweaks the logic to only load the configuration once per run. We were loading the file twice, once to figure out ports and a second time for volumes.