### PR TITLE
isServiceUp must honor --no-check

### DIFF
--- a/pkg/cli/cc/cc.go
+++ b/pkg/cli/cc/cc.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aserto-dev/clui"
 	"github.com/aserto-dev/topaz/pkg/cli/cc/iostream"
 	"github.com/aserto-dev/topaz/pkg/cli/dockerx"
+	"github.com/fullstorydev/grpcurl"
 	"github.com/samber/lo"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type CommonCtx struct {
@@ -49,4 +54,29 @@ func (c *CommonCtx) CheckRunStatus(containerName string, expectedStatus runStatu
 	}
 
 	return lo.Ternary(running, StatusRunning, StatusNotRunning) == expectedStatus
+}
+
+func (c *CommonCtx) IsServing(grpcAddress string) bool {
+	if c.NoCheck {
+		return false
+	}
+
+	tlsConf, err := grpcurl.ClientTLSConfig(true, "", "", "")
+	if err != nil {
+		return false
+	}
+
+	creds := credentials.NewTLS(tlsConf)
+
+	opts := []grpc.DialOption{
+		grpc.WithUserAgent("topaz/dev-build (no version set)"),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err = grpcurl.BlockingDial(ctx, "tcp", grpcAddress, creds, opts...)
+
+	return err == nil
 }

--- a/pkg/cli/cmd/backup.go
+++ b/pkg/cli/cmd/backup.go
@@ -19,7 +19,7 @@ type BackupCmd struct {
 const defaultFileName = "backup.tar.gz"
 
 func (cmd *BackupCmd) Run(c *cc.CommonCtx) error {
-	if !isServiceUp(cmd.Host) {
+	if !c.IsServing(cmd.Host) {
 		return errors.Wrap(ErrNotServing, cmd.Host)
 	}
 

--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -1,14 +1,7 @@
 package cmd
 
 import (
-	"context"
 	"errors"
-	"time"
-
-	"github.com/fullstorydev/grpcurl"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 var (
@@ -46,25 +39,4 @@ type CLI struct {
 	Save      SaveCmd      `cmd:"" help:"save manifest to file  (DEPRECATED)" hidden:""`
 	Version   VersionCmd   `cmd:"" help:"version information"`
 	NoCheck   bool         `name:"no-check" short:"N" env:"TOPAZ_NO_CHECK" help:"disable local container status check"`
-}
-
-func isServiceUp(grpcAddress string) bool {
-	tlsConf, err := grpcurl.ClientTLSConfig(true, "", "", "")
-	if err != nil {
-		return false
-	}
-
-	creds := credentials.NewTLS(tlsConf)
-
-	opts := []grpc.DialOption{
-		grpc.WithUserAgent("topaz/dev-build (no version set)"),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	_, err = grpcurl.BlockingDial(ctx, "tcp", grpcAddress, creds, opts...)
-
-	return err == nil
 }

--- a/pkg/cli/cmd/exporter.go
+++ b/pkg/cli/cmd/exporter.go
@@ -17,7 +17,7 @@ type ExportCmd struct {
 }
 
 func (cmd *ExportCmd) Run(c *cc.CommonCtx) error {
-	if !isServiceUp(cmd.Host) {
+	if !c.IsServing(cmd.Host) {
 		return errors.Wrap(ErrNotServing, cmd.Host)
 	}
 	color.Green(">>> exporting data to %s", cmd.Directory)

--- a/pkg/cli/cmd/importer.go
+++ b/pkg/cli/cmd/importer.go
@@ -19,7 +19,7 @@ type ImportCmd struct {
 }
 
 func (cmd *ImportCmd) Run(c *cc.CommonCtx) error {
-	if !isServiceUp(cmd.Host) {
+	if !c.IsServing(cmd.Host) {
 		return errors.Wrap(ErrNotServing, cmd.Host)
 	}
 	color.Green(">>> importing data from %s", cmd.Directory)

--- a/pkg/cli/cmd/manifest.go
+++ b/pkg/cli/cmd/manifest.go
@@ -37,7 +37,7 @@ type DeleteManifestCmd struct {
 }
 
 func (cmd *GetManifestCmd) Run(c *cc.CommonCtx) error {
-	if !isServiceUp(cmd.Host) {
+	if !c.IsServing(cmd.Host) {
 		return errors.Wrap(ErrNotServing, cmd.Host)
 	}
 	dirClient, err := clients.NewDirectoryClient(c, &cmd.Config)
@@ -70,7 +70,7 @@ func (cmd *GetManifestCmd) Run(c *cc.CommonCtx) error {
 }
 
 func (cmd *SetManifestCmd) Run(c *cc.CommonCtx) error {
-	if !isServiceUp(cmd.Host) {
+	if !c.IsServing(cmd.Host) {
 		return errors.Wrap(ErrNotServing, cmd.Host)
 	}
 	dirClient, err := clients.NewDirectoryClient(c, &cmd.Config)
@@ -92,7 +92,7 @@ func (cmd *SetManifestCmd) Run(c *cc.CommonCtx) error {
 }
 
 func (cmd *DeleteManifestCmd) Run(c *cc.CommonCtx) error {
-	if !isServiceUp(cmd.Host) {
+	if !c.IsServing(cmd.Host) {
 		return errors.Wrap(ErrNotServing, cmd.Host)
 	}
 	dirClient, err := clients.NewDirectoryClient(c, &cmd.Config)

--- a/pkg/cli/cmd/restore.go
+++ b/pkg/cli/cmd/restore.go
@@ -18,7 +18,7 @@ type RestoreCmd struct {
 }
 
 func (cmd *RestoreCmd) Run(c *cc.CommonCtx) error {
-	if !isServiceUp(cmd.Host) {
+	if !c.IsServing(cmd.Host) {
 		return errors.Wrap(ErrNotServing, cmd.Host)
 	}
 	cmd.Config.SessionID = uuid.NewString()


### PR DESCRIPTION
`isServiceUp` fails when running in Github Action, and there is no way to bypass the check! 

This PR makes it:
* honor `--no-check`
* moves it to the `cc.IsServing()`  similar to `cc.CheckRunStatus()` 