### PR TITLE
fix localbundles

### DIFF
--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -40,5 +40,5 @@ type CLI struct {
 	Save      SaveCmd      `cmd:"" help:"save manifest to file  (DEPRECATED)" hidden:""`
 	Version   VersionCmd   `cmd:"" help:"version information"`
 	NoCheck   bool         `name:"no-check" short:"N" env:"TOPAZ_NO_CHECK" help:"disable local container status check"`
-	LogLevel  int          `name:"log" short:"l" type:"counter" default:"0" help:"log level"`
+	LogLevel  int          `name:"log" short:"L" type:"counter" default:"0" help:"log level"`
 }

--- a/pkg/cli/cmd/startrun.go
+++ b/pkg/cli/cmd/startrun.go
@@ -141,8 +141,11 @@ func getVolumes(cfg *config.Loader) ([]string, error) {
 		return dir, fmt.Sprintf("%s:%s", dir, fmt.Sprintf("/%s", filepath.Base(dir)))
 	})
 
-	// manually attach the configuration folder
-	volumes := []string{fmt.Sprintf("%s:/config:ro", cc.GetTopazCfgDir())}
+	volumes := []string{
+		fmt.Sprintf("%s:/config:ro", cc.GetTopazCfgDir()),        // manually attach the configuration folder
+		fmt.Sprintf("%s:/root/.policy:ro", dockerx.PolicyRoot()), // manually attache policy store
+	}
+
 	for _, v := range volumeMap {
 		volumes = append(volumes, v)
 	}


### PR DESCRIPTION
* fix regression in 0.31.5 not setting the policy file store, preventing local bundles to load
* fix short argument clash between `topaz configure -l ` and the global `--log` short which should have been a capital `L` instead of lowercase `l`