### PR TITLE
Fix `ds.object` with_relations

### DIFF
--- a/builtins/edge/ds/object.go
+++ b/builtins/edge/ds/object.go
@@ -21,8 +21,7 @@ import (
 )
 
 type objResult struct {
-	ID        string           `json:"id"`
-	Type      string           `json:"type"`
+	*dsc3.Object
 	Relations []*dsc3.Relation `json:"relations,omitempty"`
 }
 
@@ -116,9 +115,8 @@ func RegisterObject(logger *zerolog.Logger, fnName string, dr resolvers.Director
 					return nil, err
 				}
 			default:
-				v3 := &objResult{
-					ID:        resp.Result.Id,
-					Type:      resp.Result.Type,
+				v3 := objResult{
+					Object:    resp.Result,
 					Relations: resp.Relations,
 				}
 

--- a/builtins/edge/ds/object.go
+++ b/builtins/edge/ds/object.go
@@ -103,9 +103,14 @@ func RegisterObject(logger *zerolog.Logger, fnName string, dr resolvers.Director
 			var result proto.Message
 
 			if resp.Result != nil {
-				result = resp.Result
-				if outputV2 {
+				switch {
+				case outputV2:
 					result = convert.ObjectToV2(resp.Result)
+				case args.WithRelations:
+					resp.Page = nil
+					result = resp
+				default:
+					result = resp.Result
 				}
 			}
 


### PR DESCRIPTION
Passing the `with_relations: true` option to `ds.object` had no effect because the builtin was assigning the returned object as the result.

This PR adds an options `relations` field alongside `type` and `id`.

Example:
```rego
obj := ds.object({
  "object_type": "user",
  "object_id": "morty@the-citadel.com",
  "with_relations": true
})
obj.id == "morty@the-citadel.com"
obj.type == "user"
obj.relations == [<array of relations>]
```