### PR TITLE
Update sidecar deployment topaz config docs

### DIFF
--- a/docs/deployments/sidecar-deployment/deployment.yaml
+++ b/docs/deployments/sidecar-deployment/deployment.yaml
@@ -17,8 +17,8 @@ spec:
       # using an init container to download the topaz edge directory db file that contains our required user informations
       initContainers:
       - name: get-eds-citadel
-        image: busybox:1.28
-        command: ["/bin/sh","-c","cd /db/;wget https://github.com/aserto-dev/topaz/raw/main/pkg/testing/assets/eds-citadel.db;"]
+        image: busybox:1.36
+        command: ["/bin/sh","-c","cd /db/;wget --no-check-certificate https://github.com/aserto-dev/topaz/raw/main/pkg/testing/assets/eds-citadel.db;"]
         volumeMounts:
         - name: topaz-db
           mountPath: "/db/"
@@ -31,6 +31,7 @@ spec:
         ports:
         - containerPort: 8282
         - containerPort: 9292
+        - containerPort: 8080
         volumeMounts:
           - name: topaz-config
             mountPath: "/config/config.yaml"

--- a/docs/deployments/sidecar-deployment/topaz-configmap.yaml
+++ b/docs/deployments/sidecar-deployment/topaz-configmap.yaml
@@ -12,7 +12,7 @@ data:
       log_level: info
     
     directory:
-      db_path: /db/directory.db
+      db_path: /db/eds-citadel.db
     
     # remote directory is used to resolve the identity for the authorizer.
     remote_directory:
@@ -27,6 +27,59 @@ data:
       health:
         listen_address: "0.0.0.0:9494"
       services:
+        console:
+          grpc:
+            listen_address: "0.0.0.0:8081"
+            # if certs are not specified default certs will be generate with the format reader_grpc.*
+            certs:
+              tls_key_path: "/root/.config/topaz/certs/grpc.key"
+              tls_cert_path: "/root/.config/topaz/certs/grpc.crt"
+              tls_ca_cert_path: "/root/.config/topaz/certs/grpc-ca.crt"
+          gateway:
+            listen_address: "0.0.0.0:8080"
+            # if not specified, the allowed_origins includes localhost by default
+            allowed_origins:
+            - http://localhost
+            - http://localhost:*
+            - https://localhost
+            - https://localhost:*
+            - https://0.0.0.0:*
+            - https://*.aserto.com
+            - https://*aserto-console.netlify.app
+            # if no certs are specified, the gateway will have the http flag enabled (http: true)
+            certs:
+              tls_key_path: "/root/.config/topaz/certs/gateway.key"
+              tls_cert_path: "/root/.config/topaz/certs/gateway.crt"
+              tls_ca_cert_path: "/root/.config/topaz/certs/gateway-ca.crt"
+
+        model:
+          grpc:
+            listen_address: "0.0.0.0:9292"
+            # if certs are not specified default certs will be generate with the format reader_grpc.*
+            certs:
+              tls_key_path: "/root/.config/topaz/certs/grpc.key"
+              tls_cert_path: "/root/.config/topaz/certs/grpc.crt"
+              tls_ca_cert_path: "/root/.config/topaz/certs/grpc-ca.crt"
+          gateway:
+            listen_address: "0.0.0.0:9393"
+            # if not specified, the allowed_origins includes localhost by default
+            allowed_origins:
+            - http://localhost
+            - http://localhost:*
+            - https://localhost
+            - https://localhost:*
+            - https://*.aserto.com
+            - https://*aserto-console.netlify.app
+            # if no certs are specified, the gateway will have the http flag enabled (http: true)
+            certs:
+              tls_key_path: "/root/.config/topaz/certs/gateway.key"
+              tls_cert_path: "/root/.config/topaz/certs/gateway.crt"
+              tls_ca_cert_path: "/root/.config/topaz/certs/gateway-ca.crt"
+            http: false
+            read_timeout: 2s # default 2 seconds
+            read_header_timeout: 2s
+            write_timeout: 2s
+            idle_timeout: 30s # default 30 seconds 
         reader:
           grpc:
             listen_address: "0.0.0.0:9292"


### PR DESCRIPTION
To access the console you will need to forward ports 8080, 8383 and 9393.
```
kubectl --namespace default port-forward $TODO_POD_NAME 8080:8080 8383:8383 9393:9393
```