### PR TITLE
cleanup generics usage

### DIFF
--- a/pkg/app/edgedir.go
+++ b/pkg/app/edgedir.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aserto-dev/topaz/pkg/rapidoc"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/samber/lo"
 	"google.golang.org/grpc"
 )
 
@@ -55,28 +56,28 @@ func (e *EdgeDir) AvailableServices() []string {
 
 func (e *EdgeDir) GetGRPCRegistrations(services ...string) builder.GRPCRegistrations {
 	return func(server *grpc.Server) {
-		if contains(services, modelService) {
+		if lo.Contains(services, modelService) {
 			dsm3.RegisterModelServer(server, e.dir.Model3())
 		}
-		if contains(services, readerService) {
+		if lo.Contains(services, readerService) {
 			if e.dir.Config().EnableV2 {
 				dsr2.RegisterReaderServer(server, e.dir.Reader2())
 			}
 			dsr3.RegisterReaderServer(server, e.dir.Reader3())
 		}
-		if contains(services, writerService) {
+		if lo.Contains(services, writerService) {
 			if e.dir.Config().EnableV2 {
 				dsw2.RegisterWriterServer(server, e.dir.Writer2())
 			}
 			dsw3.RegisterWriterServer(server, e.dir.Writer3())
 		}
-		if contains(services, importerService) {
+		if lo.Contains(services, importerService) {
 			if e.dir.Config().EnableV2 {
 				dsi2.RegisterImporterServer(server, e.dir.Importer2())
 			}
 			dsi3.RegisterImporterServer(server, e.dir.Importer3())
 		}
-		if contains(services, exporterService) {
+		if lo.Contains(services, exporterService) {
 			if e.dir.Config().EnableV2 {
 				dse2.RegisterExporterServer(server, e.dir.Exporter2())
 			}
@@ -87,7 +88,7 @@ func (e *EdgeDir) GetGRPCRegistrations(services ...string) builder.GRPCRegistrat
 
 func (e *EdgeDir) GetGatewayRegistration(services ...string) builder.HandlerRegistrations {
 	return func(ctx context.Context, mux *runtime.ServeMux, grpcEndpoint string, opts []grpc.DialOption) error {
-		if contains(services, modelService) {
+		if lo.Contains(services, modelService) {
 			err := dsm3.RegisterModelHandlerFromEndpoint(ctx, mux, grpcEndpoint, opts)
 			if err != nil {
 				return err
@@ -96,25 +97,25 @@ func (e *EdgeDir) GetGatewayRegistration(services ...string) builder.HandlerRegi
 				return err
 			}
 		}
-		if contains(services, readerService) {
+		if lo.Contains(services, readerService) {
 			err := dsr3.RegisterReaderHandlerFromEndpoint(ctx, mux, grpcEndpoint, opts)
 			if err != nil {
 				return err
 			}
 		}
-		if contains(services, writerService) {
+		if lo.Contains(services, writerService) {
 			err := dsw3.RegisterWriterHandlerFromEndpoint(ctx, mux, grpcEndpoint, opts)
 			if err != nil {
 				return err
 			}
 		}
-		if contains(services, importerService) {
+		if lo.Contains(services, importerService) {
 			err := dsi3.RegisterImporterHandlerFromEndpoint(ctx, mux, grpcEndpoint, opts)
 			if err != nil {
 				return err
 			}
 		}
-		if contains(services, exporterService) {
+		if lo.Contains(services, exporterService) {
 			err := dse3.RegisterExporterHandlerFromEndpoint(ctx, mux, grpcEndpoint, opts)
 			if err != nil {
 				return err

--- a/pkg/app/topaz.go
+++ b/pkg/app/topaz.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aserto-dev/topaz/pkg/app/auth"
 	"github.com/aserto-dev/topaz/pkg/app/handlers"
 	"github.com/aserto-dev/topaz/pkg/app/middlewares"
+	"github.com/samber/lo"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 
@@ -60,7 +61,7 @@ func (e *Topaz) Start() error {
 		if len(cfg.Needs) > 0 {
 			for _, name := range cfg.Needs {
 				if dependencyConfig, ok := e.Configuration.APIConfig.Services[name]; ok {
-					if !contains(e.Manager.DependencyMap[cfg.GRPC.ListenAddress], dependencyConfig.GRPC.ListenAddress) &&
+					if !lo.Contains(e.Manager.DependencyMap[cfg.GRPC.ListenAddress], dependencyConfig.GRPC.ListenAddress) &&
 						cfg.GRPC.ListenAddress != dependencyConfig.GRPC.ListenAddress {
 						e.Manager.DependencyMap[cfg.GRPC.ListenAddress] = append(e.Manager.DependencyMap[cfg.GRPC.ListenAddress], dependencyConfig.GRPC.ListenAddress)
 					}
@@ -119,7 +120,7 @@ func (e *Topaz) ConfigServices() error {
 		for _, serv := range e.Services {
 			notAdded := true
 			for _, serviceName := range serv.AvailableServices() {
-				if contains(serviceConfig.registeredServices, serviceName) && notAdded {
+				if lo.Contains(serviceConfig.registeredServices, serviceName) && notAdded {
 					grpcs = append(grpcs, serv.GetGRPCRegistrations(serviceConfig.registeredServices...))
 					gateways = append(gateways, serv.GetGatewayRegistration(serviceConfig.registeredServices...))
 					cleanups = append(cleanups, serv.Cleanups()...)
@@ -163,7 +164,7 @@ func (e *Topaz) ConfigServices() error {
 			}
 
 			consoleConfig := con.(*ConsoleService).PrepareConfig(e.Configuration)
-			if contains(serviceConfig.registeredServices, "console") {
+			if lo.Contains(serviceConfig.registeredServices, "console") {
 				server.Gateway.Mux.Handle("/ui/", handlers.UIHandler(http.FS(console.FS)))
 				server.Gateway.Mux.Handle("/public/", handlers.UIHandler(http.FS(console.FS)))
 				server.Gateway.Mux.HandleFunc("/api/v1/config", handlers.ConfigHandler(consoleConfig))
@@ -263,15 +264,6 @@ func mapToGRPCPorts(api map[string]*builder.API) map[string]services {
 	return portMap
 }
 
-func contains[T comparable](slice []T, item T) bool {
-	for i := range slice {
-		if slice[i] == item {
-			return true
-		}
-	}
-	return false
-}
-
 func (e *Topaz) GetDecisionLogger(cfg config.DecisionLogConfig) (decisionlog.DecisionLogger, error) {
 	var decisionlogger decisionlog.DecisionLogger
 	var err error
@@ -333,7 +325,7 @@ func (e *Topaz) validateConfig() error {
 	for key := range e.Configuration.APIConfig.Services {
 		validKey := false
 		for _, service := range e.Services {
-			if contains(service.AvailableServices(), key) {
+			if lo.Contains(service.AvailableServices(), key) {
 				validKey = true
 				break
 			}

--- a/plugins/edge/sync.go
+++ b/plugins/edge/sync.go
@@ -17,8 +17,8 @@ import (
 	dsm3 "github.com/aserto-dev/go-directory/aserto/directory/model/v3"
 	dsr3 "github.com/aserto-dev/go-directory/aserto/directory/reader/v3"
 	dsw3 "github.com/aserto-dev/go-directory/aserto/directory/writer/v3"
-	"github.com/aserto-dev/go-edge-ds/pkg/ds"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 
 	"github.com/aserto-dev/go-aserto/client"
 	topaz "github.com/aserto-dev/topaz/pkg/cc/config"
@@ -605,7 +605,7 @@ func getObjectKey(obj *dsc3.Object) []byte {
 func getRelationKey(rel *dsc3.Relation) []byte {
 	return []byte(fmt.Sprintf("%s:%s#%s@%s:%s%s",
 		rel.ObjectType, rel.ObjectId, rel.Relation, rel.SubjectType, rel.SubjectId,
-		ds.Iff(rel.SubjectRelation == "", "", fmt.Sprintf("#%s", rel.SubjectRelation))))
+		lo.Ternary(rel.SubjectRelation == "", "", fmt.Sprintf("#%s", rel.SubjectRelation))))
 }
 
 func fullSync(wm *watermark) bool {


### PR DESCRIPTION
* use `samber/lo` generic func when exists instead of private implementations