### PR TITLE
topaz config info

### DIFF
--- a/cmd/topaz/main.go
+++ b/cmd/topaz/main.go
@@ -45,6 +45,7 @@ func main() {
 		kong.Name(x.AppName),
 		kong.Description(x.AppDescription),
 		kong.UsageOnError(),
+		kong.Exit(exit),
 		kong.ConfigureHelp(kong.HelpOptions{
 			NoAppSummary:        false,
 			Summary:             false,
@@ -110,4 +111,11 @@ func checkDBFiles(topazDBDir string) (bool, error) {
 	}
 
 	return len(files) > 0, nil
+}
+
+func exit(x int) {
+	if len(os.Args) == 1 {
+		os.Exit(0)
+	}
+	os.Exit(x)
 }

--- a/cmd/topaz/main.go
+++ b/cmd/topaz/main.go
@@ -113,9 +113,10 @@ func checkDBFiles(topazDBDir string) (bool, error) {
 	return len(files) > 0, nil
 }
 
-func exit(x int) {
+// set status code to 0 when executing with no arguments, help only output.
+func exit(rc int) {
 	if len(os.Args) == 1 {
 		os.Exit(0)
 	}
-	os.Exit(x)
+	os.Exit(rc)
 }

--- a/cmd/topaz/main.go
+++ b/cmd/topaz/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/cmd"
@@ -65,6 +66,15 @@ func main() {
 			"container_tag":      cc.ContainerTag(),
 			"container_platform": cc.ContainerPlatform(),
 			"container_name":     cc.ContainerName(ctx.Config.Active.ConfigFile),
+			"directory_svc":      cc.DirectorySvc(),
+			"directory_key":      cc.DirectoryKey(),
+			"directory_token":    cc.DirectoryToken(),
+			"authorizer_svc":     cc.AuthorizerSvc(),
+			"authorizer_key":     cc.AuthorizerKey(),
+			"authorizer_token":   cc.AuthorizerToken(),
+			"tenant_id":          cc.TenantID(),
+			"insecure":           strconv.FormatBool(cc.Insecure()),
+			"no_check":           strconv.FormatBool(cc.NoCheck()),
 		},
 	)
 	zerolog.SetGlobalLevel(logLevel(cli.LogLevel))

--- a/pkg/cli/cc/client.go
+++ b/pkg/cli/cc/client.go
@@ -1,0 +1,85 @@
+package cc
+
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	defaultDirectorySvc    = "localhost:9292"
+	defaultDirectoryKey    = ""
+	defaultDirectoryToken  = ""
+	defaultAuthorizerSvc   = "localhost:8282"
+	defaultAuthorizerKey   = ""
+	defaultAuthorizerToken = ""
+	defaultTenantID        = ""
+	defaultInsecure        = false
+	defaultNoCheck         = false
+)
+
+func DirectorySvc() string {
+	if directorySvc := os.Getenv("TOPAZ_DIRECTORY_SVC"); directorySvc != "" {
+		return directorySvc
+	}
+	return defaultDirectorySvc
+}
+
+func DirectoryKey() string {
+	if directoryKey := os.Getenv("TOPAZ_DIRECTORY_KEY"); directoryKey != "" {
+		return directoryKey
+	}
+	return defaultDirectoryKey
+}
+
+func DirectoryToken() string {
+	if directoryToken := os.Getenv("TOPAZ_DIRECTORY_TOKEN"); directoryToken != "" {
+		return directoryToken
+	}
+	return defaultDirectoryToken
+}
+
+func AuthorizerSvc() string {
+	if authorizerSvc := os.Getenv("TOPAZ_AUTHORIZER_SVC"); authorizerSvc != "" {
+		return authorizerSvc
+	}
+	return defaultAuthorizerSvc
+}
+
+func AuthorizerKey() string {
+	if authorizerKey := os.Getenv("TOPAZ_AUTHORIZER_KEY"); authorizerKey != "" {
+		return authorizerKey
+	}
+	return defaultAuthorizerKey
+}
+
+func AuthorizerToken() string {
+	if authorizerToken := os.Getenv("TOPAZ_AUTHORIZER_TOKEN"); authorizerToken != "" {
+		return authorizerToken
+	}
+	return defaultAuthorizerToken
+}
+
+func TenantID() string {
+	if tenantID := os.Getenv("ASERTO_TENANT_ID"); tenantID != "" {
+		return tenantID
+	}
+	return defaultTenantID
+}
+
+func Insecure() bool {
+	if insecure := os.Getenv("TOPAZ_INSECURE"); insecure != "" {
+		if b, err := strconv.ParseBool(insecure); err == nil {
+			return b
+		}
+	}
+	return defaultInsecure
+}
+
+func NoCheck() bool {
+	if noCheck := os.Getenv("TOPAZ_NO_CHECK"); noCheck != "" {
+		if b, err := strconv.ParseBool(noCheck); err == nil {
+			return b
+		}
+	}
+	return defaultNoCheck
+}

--- a/pkg/cli/clients/authorizer_client.go
+++ b/pkg/cli/clients/authorizer_client.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"fmt"
 
 	azc "github.com/aserto-dev/go-aserto/client"
 	"github.com/fullstorydev/grpcurl"
@@ -14,23 +15,17 @@ import (
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 )
 
-const (
-	localhostAuthorizer   string = "localhost:8282"
-	EnvTopazAuthorizerSvc string = "TOPAZ_AUTHORIZER_SVC"
-	EnvTopazAuthorizerKey string = "TOPAZ_AUTHORIZER_KEY"
-)
-
 type AuthorizerConfig struct {
-	Host     string `flag:"host" short:"H" env:"TOPAZ_AUTHORIZER_SVC" help:"authorizer service address"`
-	APIKey   string `flag:"api-key" short:"k" env:"TOPAZ_AUTHORIZER_KEY" help:"authorizer API key"`
-	Token    string `flag:"token" short:"t" env:"TOPAZ_AUTHORIZER_TOKEN" help:"authorizer OAuth2.0 token" hidden:""`
-	Insecure bool   `flag:"insecure" short:"i" env:"INSECURE" help:"skip TLS verification"`
-	TenantID string `flag:"tenant-id" help:"" env:"ASERTO_TENANT_ID" `
+	Host     string `flag:"host" short:"H" default:"${authorizer_svc}" env:"TOPAZ_AUTHORIZER_SVC" help:"authorizer service address"`
+	APIKey   string `flag:"api-key" short:"k" default:"${authorizer_key}" env:"TOPAZ_AUTHORIZER_KEY" help:"authorizer API key"`
+	Token    string `flag:"token" short:"t" default:"${authorizer_token}" env:"TOPAZ_AUTHORIZER_TOKEN" help:"authorizer OAuth2.0 token" hidden:""`
+	Insecure bool   `flag:"insecure" short:"i" default:"${insecure}" env:"TOPAZ_INSECURE" help:"skip TLS verification"`
+	TenantID string `flag:"tenant-id" help:"" default:"${tenant_id}" env:"ASERTO_TENANT_ID" `
 }
 
 func NewAuthorizerClient(c *cc.CommonCtx, cfg *AuthorizerConfig) (authorizer.AuthorizerClient, error) {
 	if cfg.Host == "" {
-		cfg.Host = localhostAuthorizer
+		return nil, fmt.Errorf("no host specified")
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/pkg/cli/clients/directory_client.go
+++ b/pkg/cli/clients/directory_client.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aserto-dev/go-aserto/client"
 	dsc "github.com/aserto-dev/go-directory-cli/client"
@@ -13,24 +14,17 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const (
-	localhostDirectory   string = "localhost:9292"
-	EnvTopazDirectorySvc string = "TOPAZ_DIRECTORY_SVC"
-	EnvTopazDirectoryKey string = "TOPAZ_DIRECTORY_KEY"
-)
-
 type DirectoryConfig struct {
-	Host     string `flag:"host" short:"H" env:"TOPAZ_DIRECTORY_SVC" help:"directory service address"`
-	APIKey   string `flag:"api-key" short:"k" env:"TOPAZ_DIRECTORY_KEY" help:"directory API key"`
-	Token    string `flag:"token" short:"t" env:"TOPAZ_DIRECTORY_TOKEN" help:"directory OAuth2.0 token" hidden:""`
-	Insecure bool   `flag:"insecure" short:"i" env:"INSECURE" help:"skip TLS verification"`
-	TenantID string `flag:"tenant-id" help:"" env:"ASERTO_TENANT_ID" `
+	Host     string `flag:"host" short:"H" default:"${directory_svc}" env:"TOPAZ_DIRECTORY_SVC" help:"directory service address"`
+	APIKey   string `flag:"api-key" short:"k" default:"${directory_key}" env:"TOPAZ_DIRECTORY_KEY" help:"directory API key"`
+	Token    string `flag:"token" short:"t" default:"${directory_token}" env:"TOPAZ_DIRECTORY_TOKEN" help:"directory OAuth2.0 token" hidden:""`
+	Insecure bool   `flag:"insecure" short:"i" default:"${insecure}" env:"TOPAZ_INSECURE" help:"skip TLS verification"`
+	TenantID string `flag:"tenant-id" help:"" default:"${tenant_id}" env:"ASERTO_TENANT_ID" `
 }
 
 func NewDirectoryClient(c *cc.CommonCtx, cfg *DirectoryConfig) (*dsc.Client, error) {
-
 	if cfg.Host == "" {
-		cfg.Host = localhostDirectory
+		return nil, fmt.Errorf("no host specified")
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/pkg/cli/cmd/config.go
+++ b/pkg/cli/cmd/config.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/adrg/xdg"
@@ -272,14 +271,32 @@ func (cmd InfoConfigCmd) Run(c *cc.CommonCtx) error {
 			"running.configuration.name": c.Config.Running.Config,
 			"running.configuration.file": c.Config.Running.ConfigFile,
 			"running.container.name":     c.Config.Running.ContainerName,
-			"topaz.json":                 filepath.Join(cc.GetTopazDir(), CLIConfigurationFile),
+
+			"topaz.json": filepath.Join(cc.GetTopazDir(), CLIConfigurationFile),
 		},
 		// default values
 		"default": map[string]interface{}{
-			"CONTAINER_IMAGE":    c.Config.Defaults.ContainerImage,
-			"CONTAINER_TAG":      c.Config.Defaults.ContainerTag,
-			"CONTAINER_PLATFORM": c.Config.Defaults.ContainerPlatform,
-			"TOPAZ_NO_CHECK":     strconv.FormatBool(c.Config.Defaults.NoCheck),
+			"CONTAINER_REGISTRY": cc.ContainerRegistry(),
+			"CONTAINER_IMAGE":    cc.ContainerImage(),
+			"CONTAINER_TAG":      cc.ContainerTag(),
+			"CONTAINER_PLATFORM": cc.ContainerPlatform(),
+			"TOPAZ_NO_CHECK":     cc.NoCheck(),
+		},
+		// directory values
+		"directory": map[string]interface{}{
+			"TOPAZ_DIRECTORY_SVC":   cc.DirectorySvc(),
+			"TOPAZ_DIRECTORY_KEY":   cc.DirectoryKey(),
+			"TOPAZ_DIRECTORY_TOKEN": cc.DirectoryToken(),
+			"TOPAZ_INSECURE":        cc.Insecure(),
+			"ASERTO_TENANT_ID":      cc.TenantID(),
+		},
+		// authorizer values
+		"authorizer": map[string]interface{}{
+			"TOPAZ_AUTHORIZER_SVC":   cc.AuthorizerSvc(),
+			"TOPAZ_AUTHORIZER_KEY":   cc.AuthorizerKey(),
+			"TOPAZ_AUTHORIZER_TOKEN": cc.AuthorizerToken(),
+			"TOPAZ_INSECURE":         cc.Insecure(),
+			"ASERTO_TENANT_ID":       cc.TenantID(),
 		},
 	}
 

--- a/pkg/cli/cmd/config.go
+++ b/pkg/cli/cmd/config.go
@@ -22,6 +22,7 @@ type ConfigCmd struct {
 	List   ListConfigCmd   `cmd:"" help:"list configurations"`
 	Rename RenameConfigCmd `cmd:"" help:"rename configuration"`
 	Delete DeleteConfigCmd `cmd:"" help:"delete configuration"`
+	Info   InfoConfigCmd   `cmd:"" help:"display configuration information"`
 }
 
 var restrictedNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]*$`)
@@ -241,5 +242,11 @@ func (cmd ListConfigCmd) Run(c *cc.CommonCtx) error {
 	}
 	table.Do()
 
+	return nil
+}
+
+type InfoConfigCmd struct{}
+
+func (cmd InfoConfigCmd) Run(c *cc.CommonCtx) error {
 	return nil
 }

--- a/pkg/cli/cmd/config.go
+++ b/pkg/cli/cmd/config.go
@@ -250,58 +250,91 @@ func (cmd ListConfigCmd) Run(c *cc.CommonCtx) error {
 type InfoConfigCmd struct{}
 
 func (cmd InfoConfigCmd) Run(c *cc.CommonCtx) error {
-	data := map[string]interface{}{
-		// environment values
-		"environment": map[string]interface{}{
-			"HOME":            xdg.Home,
-			"XDG_CONFIG_HOME": xdg.ConfigHome,
-			"XDG_DATA_HOME":   xdg.DataHome,
-		},
-		// config values
-		"config": map[string]interface{}{
-			"TOPAZ_CFG_DIR":   cc.GetTopazCfgDir(),
-			"TOPAZ_CERTS_DIR": cc.GetTopazCertsDir(),
-			"TOPAZ_DB_DIR":    cc.GetTopazDataDir(),
-			"TOPAZ_DIR":       cc.GetTopazDir(),
-		},
-		// runtime values
-		"runtime": map[string]interface{}{
-			"active.configuration.name":  c.Config.Active.Config,
-			"active.configuration.file":  c.Config.Active.ConfigFile,
-			"running.configuration.name": c.Config.Running.Config,
-			"running.configuration.file": c.Config.Running.ConfigFile,
-			"running.container.name":     c.Config.Running.ContainerName,
-
-			"topaz.json": filepath.Join(cc.GetTopazDir(), CLIConfigurationFile),
-		},
-		// default values
-		"default": map[string]interface{}{
-			"CONTAINER_REGISTRY": cc.ContainerRegistry(),
-			"CONTAINER_IMAGE":    cc.ContainerImage(),
-			"CONTAINER_TAG":      cc.ContainerTag(),
-			"CONTAINER_PLATFORM": cc.ContainerPlatform(),
-			"TOPAZ_NO_CHECK":     cc.NoCheck(),
-		},
-		// directory values
-		"directory": map[string]interface{}{
-			"TOPAZ_DIRECTORY_SVC":   cc.DirectorySvc(),
-			"TOPAZ_DIRECTORY_KEY":   cc.DirectoryKey(),
-			"TOPAZ_DIRECTORY_TOKEN": cc.DirectoryToken(),
-			"TOPAZ_INSECURE":        cc.Insecure(),
-			"ASERTO_TENANT_ID":      cc.TenantID(),
-		},
-		// authorizer values
-		"authorizer": map[string]interface{}{
-			"TOPAZ_AUTHORIZER_SVC":   cc.AuthorizerSvc(),
-			"TOPAZ_AUTHORIZER_KEY":   cc.AuthorizerKey(),
-			"TOPAZ_AUTHORIZER_TOKEN": cc.AuthorizerToken(),
-			"TOPAZ_INSECURE":         cc.Insecure(),
-			"ASERTO_TENANT_ID":       cc.TenantID(),
-		},
-	}
-
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
-	return enc.Encode(data)
+	return enc.Encode(cmd.info(c))
+}
+
+type Info struct {
+	Environment struct {
+		Home          string `json:"home"`
+		XdgConfigHome string `json:"xdg_config_home"`
+		XdgDataHome   string `json:"xdg_data_home"`
+	} `json:"environment"`
+	Config struct {
+		TopazCfgDir   string `json:"topaz_cfg_dir"`
+		TopazCertsDir string `json:"topaz_certs_dir"`
+		TopazDataDir  string `json:"topaz_db_dir"`
+		TopazDir      string `json:"topaz_dir"`
+	} `json:"config"`
+	Runtime struct {
+		ActiveConfigurationName  string `json:"active_configuration_name"`
+		ActiveConfigurationFile  string `json:"active_configuration_file"`
+		RunningConfigurationName string `json:"running_configuration_name"`
+		RunningConfigurationFile string `json:"running_configuration_file"`
+		RunningContainerName     string `json:"running_container_name"`
+		TopazConfigFile          string `json:"topaz_json"`
+	} `json:"runtime"`
+	Default struct {
+		ContainerRegistry string `json:"container_registry"`
+		ContainerImage    string `json:"container_image"`
+		ContainerTag      string `json:"container_tag"`
+		ContainerPlatform string `json:"container_platform"`
+		NoCheck           bool   `json:"topaz_no_check"`
+	} `json:"default"`
+	Directory struct {
+		DirectorySvc   string `json:"topaz_directory_svc"`
+		DirectoryKey   string `json:"topaz_directory_key"`
+		DirectoryToken string `json:"topaz_directory_token"`
+		Insecure       bool   `json:"topaz_insecure"`
+		TenantID       string `json:"aserto_tenant_id"`
+	} `json:"directory"`
+	Authorizer struct {
+		AuthorizerSvc   string `json:"topaz_authorizer_svc"`
+		AuthorizerKey   string `json:"topaz_authorizer_key"`
+		AuthorizerToken string `json:"topaz_authorizer_token"`
+		Insecure        bool   `json:"topaz_insecure"`
+		TenantID        string `json:"aserto_tenant_id"`
+	} `json:"authorizer"`
+}
+
+func (cmd InfoConfigCmd) info(c *cc.CommonCtx) *Info {
+	info := Info{}
+
+	info.Environment.Home = xdg.Home
+	info.Environment.XdgConfigHome = xdg.ConfigHome
+	info.Environment.XdgDataHome = xdg.DataHome
+
+	info.Config.TopazCfgDir = cc.GetTopazCfgDir()
+	info.Config.TopazCertsDir = cc.GetTopazCertsDir()
+	info.Config.TopazDataDir = cc.GetTopazDataDir()
+	info.Config.TopazDir = cc.GetTopazDir()
+
+	info.Runtime.ActiveConfigurationName = c.Config.Active.Config
+	info.Runtime.ActiveConfigurationFile = c.Config.Active.ConfigFile
+	info.Runtime.RunningConfigurationName = c.Config.Running.Config
+	info.Runtime.RunningConfigurationFile = c.Config.Running.ConfigFile
+	info.Runtime.RunningContainerName = c.Config.Running.ContainerName
+	info.Runtime.TopazConfigFile = filepath.Join(cc.GetTopazDir(), CLIConfigurationFile)
+
+	info.Default.ContainerRegistry = cc.ContainerRegistry()
+	info.Default.ContainerImage = cc.ContainerImage()
+	info.Default.ContainerTag = cc.ContainerTag()
+	info.Default.ContainerPlatform = cc.ContainerPlatform()
+	info.Default.NoCheck = cc.NoCheck()
+
+	info.Directory.DirectorySvc = cc.DirectorySvc()
+	info.Directory.DirectoryKey = cc.DirectoryKey()
+	info.Directory.DirectoryToken = cc.DirectoryToken()
+	info.Directory.Insecure = cc.Insecure()
+	info.Directory.TenantID = cc.TenantID()
+
+	info.Authorizer.AuthorizerSvc = cc.AuthorizerSvc()
+	info.Authorizer.AuthorizerKey = cc.AuthorizerKey()
+	info.Authorizer.AuthorizerToken = cc.AuthorizerToken()
+	info.Authorizer.Insecure = cc.Insecure()
+	info.Authorizer.TenantID = cc.TenantID()
+
+	return &info
 }

--- a/pkg/cli/cmd/config.go
+++ b/pkg/cli/cmd/config.go
@@ -286,7 +286,5 @@ func (cmd InfoConfigCmd) Run(c *cc.CommonCtx) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
-	enc.Encode(data)
-
-	return nil
+	return enc.Encode(data)
 }


### PR DESCRIPTION
Add `topaz config info` to list config and runtime data to aid in troubleshooting.

The `environment` section lists the external inputs, which are used to construct the `config` values, which can be overridden by their environment variable instance. 

The `runtime` section relays which configuration is active and, if one is active, which configuration is running. The information in the `runtime` section can be empty when there is no active configuration, which implies there cannot be one running either.

The `default` section denotes configuration-level defaults, which can be overridden via the `defaults` section in the `topaz.json` file or via their environment variable instance.

Example output of the `topaz config info` command:

```
{
  "environment": {
    "home": "/Users/gertd",
    "xdg_config_home": "/Users/gertd/.config",
    "xdg_data_home": "/Users/gertd/.local/share"
  },
  "config": {
    "topaz_cfg_dir": "/Users/gertd/.config/topaz/cfg",
    "topaz_certs_dir": "/Users/gertd/.local/share/topaz/certs",
    "topaz_db_dir": "/Users/gertd/.local/share/topaz/db",
    "topaz_dir": "/Users/gertd/.config/topaz"
  },
  "runtime": {
    "active_configuration_name": "peoplefinder",
    "active_configuration_file": "/Users/gertd/.config/topaz/cfg/peoplefinder.yaml",
    "running_configuration_name": "peoplefinder",
    "running_configuration_file": "/Users/gertd/.config/topaz/cfg/peoplefinder.yaml",
    "running_container_name": "topaz-peoplefinder",
    "topaz_json": "/Users/gertd/.config/topaz/topaz.json"
  },
  "default": {
    "container_registry": "ghcr.io/aserto-dev",
    "container_image": "topaz",
    "container_tag": "0.32.1",
    "container_platform": "linux/amd64",
    "topaz_no_check": false
  },
  "directory": {
    "topaz_directory_svc": "localhost:9292",
    "topaz_directory_key": "",
    "topaz_directory_token": "",
    "topaz_insecure": true,
    "aserto_tenant_id": ""
  },
  "authorizer": {
    "topaz_authorizer_svc": "localhost:8282",
    "topaz_authorizer_key": "",
    "topaz_authorizer_token": "",
    "topaz_insecure": true,
    "aserto_tenant_id": ""
  }
}
```