### PR TITLE
impl topaz config info get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/google/wire v0.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
+	github.com/itchyny/gojq v0.12.15
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/magefile/mage v1.15.0
 	github.com/mennanov/fmutils v0.3.0
@@ -116,6 +117,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jhump/protoreflect v1.16.0 // indirect
 	github.com/klauspost/compress v1.17.8 // indirect
 	github.com/kyokomi/emoji v2.2.4+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -737,6 +737,10 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.15 h1:WC1Nxbx4Ifw5U2oQWACYz32JK8G9qxNtHzrvW4KEcqI=
+github.com/itchyny/gojq v0.12.15/go.mod h1:uWAHCbCIla1jiNxmeT5/B5mOjSdfkCq6p8vxWg+BM10=
+github.com/itchyny/timefmt-go v0.1.5 h1:G0INE2la8S6ru/ZI5JecgyzbbJNs5lG1RcBqa7Jm6GE=
+github.com/itchyny/timefmt-go v0.1.5/go.mod h1:nEP7L+2YmAbT2kZ2HfSs1d8Xtw9LY8D2stDBckWakZ8=
 github.com/jhump/protoreflect v1.16.0 h1:54fZg+49widqXYQ0b+usAFHbMkBGR4PpXrsHc8+TBDg=
 github.com/jhump/protoreflect v1.16.0/go.mod h1:oYPd7nPvcBw/5wlDfm/AVmU9zH9BgqGCI469pGxfj/8=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/pkg/cli/cmd/configure/info.go
+++ b/pkg/cli/cmd/configure/info.go
@@ -48,7 +48,7 @@ func (cmd InfoConfigCmd) Run(c *cc.CommonCtx) error {
 		if s, ok := v.(string); ok && cmd.Raw {
 			fmt.Fprintf(os.Stdout, "%s\n", s)
 		} else {
-			enc.Encode(v)
+			_ = enc.Encode(v)
 		}
 	}
 

--- a/pkg/cli/cmd/configure/info.go
+++ b/pkg/cli/cmd/configure/info.go
@@ -2,21 +2,57 @@ package configure
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/adrg/xdg"
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/cmd/common"
+
+	"github.com/adrg/xdg"
+	"github.com/itchyny/gojq"
 )
 
-type InfoConfigCmd struct{}
+type InfoConfigCmd struct {
+	Var string `arg:"" optional:"" help:"configuration variable"`
+	Raw bool   `flag:"" short:"r" help:"output raw strings"`
+}
 
 func (cmd InfoConfigCmd) Run(c *cc.CommonCtx) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
-	return enc.Encode(cmd.info(c))
+
+	// use Info struct when output all, to preserve ordering of root objects.
+	if cmd.Var == "" {
+		return enc.Encode(cmd.info(c))
+	}
+
+	query, err := gojq.Parse("." + cmd.Var)
+	if err != nil {
+		return err
+	}
+
+	iter := query.Run(cmd.json(c))
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			if err, ok := err.(*gojq.HaltError); ok && err.Value() == nil {
+				break
+			}
+			return err
+		}
+		if s, ok := v.(string); ok && cmd.Raw {
+			fmt.Fprintf(os.Stdout, "%s\n", s)
+		} else {
+			enc.Encode(v)
+		}
+	}
+
+	return nil
 }
 
 type Info struct {
@@ -100,4 +136,11 @@ func (cmd InfoConfigCmd) info(c *cc.CommonCtx) *Info {
 	info.Authorizer.TenantID = cc.TenantID()
 
 	return &info
+}
+
+func (cmd InfoConfigCmd) json(c *cc.CommonCtx) map[string]any {
+	var j map[string]any
+	buf, _ := json.Marshal(cmd.info(c))
+	_ = json.Unmarshal(buf, &j)
+	return j
 }


### PR DESCRIPTION
This PR adds the ability to extract values from the info result set

Extract `config` object out of `info` result set

```
topaz config info config
{
  "topaz_certs_dir": "/Users/gertd/.local/share/topaz/certs",
  "topaz_cfg_dir": "/Users/gertd/.config/topaz/cfg",
  "topaz_db_dir": "/Users/gertd/.local/share/topaz/db",
  "topaz_dir": "/Users/gertd/.config/topaz"
}
```

Extract `topaz_certs_dir` value out of `config` sub-object

```
 topaz config info config.topaz_certs_dir
"/Users/gertd/.local/share/topaz/certs"
```

Extract `topaz_certs_dir` value out of `config` sub-object with --raw | -r option to remove quotes from string.

```
topaz config info config.topaz_certs_dir -r
/Users/gertd/.local/share/topaz/certs
```