### PR TITLE
update xdg_config_home on Windows to USERPROFILE/.config

### DIFF
--- a/makefile
+++ b/makefile
@@ -66,10 +66,15 @@ lint:
 # github.com/aserto-dev/topaz/pkg/app/tests/$PKGS
 PKGS = authz builtin manifest policy query
 .PHONY: test
-test: $(PKGS)
+test: $(PKGS) test-xdg
 $(PKGS):
 	@echo -e "$(ATTN_COLOR)==> test github.com/aserto-dev/topaz/pkg/app/tests/$@/... $(NO_COLOR)"
 	@${EXT_BIN_DIR}/gotestsum --format short-verbose -- -count=1 -parallel=1 -v -coverprofile=cover.out -coverpkg=./... github.com/aserto-dev/topaz/pkg/app/tests/$@/...;
+
+.PHONY: test-xdg
+test-xdg:
+	@echo -e "$(ATTN_COLOR)==> test github.com/aserto-dev/topaz/pkg/cli/xdg/... $(NO_COLOR)"
+	@${EXT_BIN_DIR}/gotestsum --format short-verbose -- -count=1 -parallel=1 -v -coverprofile=cover.out -coverpkg=./... github.com/adrg/xdg/...;
 
 .PHONY: write-version
 write-version:

--- a/pkg/cli/xdg/paths_windows.go
+++ b/pkg/cli/xdg/paths_windows.go
@@ -25,7 +25,7 @@ func initBaseDirs(home string, kf *knownFolders) {
 	// Initialize standard directories.
 	baseDirs.dataHome = xdgPath(envDataHome, kf.localAppData)
 	baseDirs.data = xdgPaths(envDataDirs, kf.roamingAppData, kf.programData)
-	baseDirs.configHome = xdgPath(envConfigHome, kf.localAppData)
+	baseDirs.configHome = xdgPath(envConfigHome, filepath.Join(home, ".config"))
 	baseDirs.config = xdgPaths(envConfigDirs, kf.programData, kf.roamingAppData)
 	baseDirs.stateHome = xdgPath(envStateHome, kf.localAppData)
 	baseDirs.cacheHome = xdgPath(envCacheHome, filepath.Join(kf.localAppData, "cache"))


### PR DESCRIPTION
Moving XDG_CONFIG_HOME to `USERPROFILE/.config`

Resulting in:
```
{
  "environment": {
    "home": "C:\\Users\\gertd",
    "xdg_config_home": "C:\\Users\\gertd\\.config",
    "xdg_data_home": "C:\\Users\\gertd\\AppData\\Local"
  },
  "config": {
    "topaz_cfg_dir": "C:\\Users\\gertd\\.config\\topaz\\cfg",
    "topaz_certs_dir": "C:\\Users\\gertd\\AppData\\Local\\topaz\\certs",
    "topaz_db_dir": "C:\\Users\\gertd\\AppData\\Local\\topaz\\db",
    "topaz_tmpl_dir": "C:\\Users\\gertd\\AppData\\Local\\topaz\\tmpl",
    "topaz_dir": "C:\\Users\\gertd\\.config\\topaz"
  }
}
```