### PR TITLE
update tests

### DIFF
--- a/pkg/cli/prompter/prompter_test.go
+++ b/pkg/cli/prompter/prompter_test.go
@@ -3,6 +3,7 @@ package prompter_test
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/aserto-dev/go-directory/aserto/directory/common/v3"
@@ -17,6 +18,10 @@ import (
 )
 
 func TestPrompter(t *testing.T) {
+	if enabled, err := strconv.ParseBool(os.Getenv("TEST_INTERACTIVE")); err != nil || !enabled {
+		t.Skip("skip interactive tests")
+	}
+
 	reqs := []proto.Message{
 		&reader.GetObjectRequest{
 			Page: &common.PaginationRequest{

--- a/pkg/testing/assets/config-local.yaml
+++ b/pkg/testing/assets/config-local.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://topaz.sh/schema/config.json
 ---
 # config schema version
 version: 2
@@ -19,9 +20,33 @@ jwt:
   acceptable_time_skew_seconds: 5 # set as default, 5 secs
 
 api:
-  health:
-    listen_address: "0.0.0.0:9494"
+  # health:
+  #   listen_address: "0.0.0.0:9494"
+  # metrics:
+  #   listen_address: "0.0.0.0:9696"
+  #   zpages: true
   services:
+    console:
+        gateway:
+          listen_address: "0.0.0.0:8080"
+          allowed_origins:
+          - http://localhost
+          - http://localhost:*
+          - https://localhost
+          - https://localhost:*
+          - https://0.0.0.0:*
+          - https://*.aserto.com
+          - https://*aserto-console.netlify.app
+          certs:
+            tls_key_path: '${TOPAZ_CERTS_DIR}/gateway.key'
+            tls_cert_path: '${TOPAZ_CERTS_DIR}/gateway.crt'
+            tls_ca_cert_path: '${TOPAZ_CERTS_DIR}/gateway-ca.crt'
+        grpc:
+          listen_address: "0.0.0.0:8081"
+          certs:
+            tls_key_path: '${TOPAZ_CERTS_DIR}/grpc.key'
+            tls_cert_path: '${TOPAZ_CERTS_DIR}/grpc.crt'
+            tls_ca_cert_path: '${TOPAZ_CERTS_DIR}/grpc-ca.crt'    # health:
     model:
       grpc:
         listen_address: "0.0.0.0:9292"

--- a/pkg/testing/assets/config-online.yaml
+++ b/pkg/testing/assets/config-online.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://topaz.sh/schema/config.json
 ---
 # config schema version
 version: 2
@@ -19,9 +20,33 @@ jwt:
   acceptable_time_skew_seconds: 5 # set as default, 5 secs
 
 api:
-  health:
-    listen_address: "0.0.0.0:9494"
+  # health:
+  #   listen_address: "0.0.0.0:9494"
+  # metrics:
+  #   listen_address: "0.0.0.0:9696"
+  #   zpages: true
   services:
+    console:
+        gateway:
+          listen_address: "0.0.0.0:8080"
+          allowed_origins:
+          - http://localhost
+          - http://localhost:*
+          - https://localhost
+          - https://localhost:*
+          - https://0.0.0.0:*
+          - https://*.aserto.com
+          - https://*aserto-console.netlify.app
+          certs:
+            tls_key_path: '${TOPAZ_CERTS_DIR}/gateway.key'
+            tls_cert_path: '${TOPAZ_CERTS_DIR}/gateway.crt'
+            tls_ca_cert_path: '${TOPAZ_CERTS_DIR}/gateway-ca.crt'
+        grpc:
+          listen_address: "0.0.0.0:8081"
+          certs:
+            tls_key_path: '${TOPAZ_CERTS_DIR}/grpc.key'
+            tls_cert_path: '${TOPAZ_CERTS_DIR}/grpc.crt'
+            tls_ca_cert_path: '${TOPAZ_CERTS_DIR}/grpc-ca.crt'  
     model:
       grpc:
         listen_address: "0.0.0.0:9292"

--- a/pkg/testing/engine.go
+++ b/pkg/testing/engine.go
@@ -39,7 +39,7 @@ type EngineHarness struct {
 func (h *EngineHarness) Cleanup() {
 	assert := require.New(h.t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	h.Engine.Manager.StopServers(ctx)
 	cancel()
 	h.cleanup()


### PR DESCRIPTION
Update tests
* add console service, which is missing from test configs
* disable health and metrics services from test configs
* skip prompter tests when TEST_INTERACTIVE is not set to TRUE
* increase test harness cleanup timeout from 5 to 10 secs