### PR TITLE
Revert "Remove can_leave_tenant relation."

### DIFF
--- a/assets/multi-tenant/manifest.yaml
+++ b/assets/multi-tenant/manifest.yaml
@@ -57,6 +57,8 @@ types:
       can_delete_tenant: owner | system->admin
       can_manage_members: can_administer
       can_list_members: can_view
+      # an owner cannot leave the tenant. they must be removed by another owner.
+      can_leave_tenant: can_view - owner
 
       can_create_resources: can_edit
       can_delete_resources: can_administer

--- a/assets/multi-tenant/test/multi-tenant_assertions.json
+++ b/assets/multi-tenant/test/multi-tenant_assertions.json
@@ -904,6 +904,56 @@
       "check": {
         "object_type": "tenant",
         "object_id": "citadel",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "rick@the-citadel.com"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "citadel",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "morty@the-citadel.com"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "citadel",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "summer@the-smiths.com"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "citadel",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "beth@the-smiths.com"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "citadel",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "jerry@the-smiths.com"
+      },
+      "expected": false
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "citadel",
         "relation": "can_create_resources",
         "subject_type": "user",
         "subject_id": "rick@the-citadel.com"
@@ -1399,6 +1449,56 @@
         "subject_id": "jerry@the-smiths.com"
       },
       "expected": true
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "smiths",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "rick@the-citadel.com"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "smiths",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "morty@the-citadel.com"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "smiths",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "summer@the-smiths.com"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "smiths",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "beth@the-smiths.com"
+      },
+      "expected": true
+    },
+    {
+      "check": {
+        "object_type": "tenant",
+        "object_id": "smiths",
+        "relation": "can_leave_tenant",
+        "subject_type": "user",
+        "subject_id": "jerry@the-smiths.com"
+      },
+      "expected": false
     },
     {
       "check": {

--- a/assets/simple-rbac/manifest.yaml
+++ b/assets/simple-rbac/manifest.yaml
@@ -13,6 +13,7 @@ types:
       manager: user
 
     permissions:
+      ### display_name: user#in_management_chain ###
       in_management_chain: manager | manager->in_management_chain
 
 


### PR DESCRIPTION
This reverts commit 03a718551a0587d2820ab282bd0c38a2889bf47c.

The exclusion permission was temporarily removed due to a bug fixed in https://github.com/aserto-dev/azm/pull/50