### PR TITLE
Support custom headers to directory and authorizer

### DIFF
--- a/cmd/topaz-db/cmd/sync.go
+++ b/cmd/topaz-db/cmd/sync.go
@@ -10,7 +10,6 @@ import (
 	eds "github.com/aserto-dev/go-edge-ds"
 	"github.com/aserto-dev/go-edge-ds/pkg/datasync"
 	"github.com/aserto-dev/go-edge-ds/pkg/directory"
-	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
 
 	"github.com/rs/zerolog"
 )
@@ -31,7 +30,7 @@ func (cmd *SyncCmd) Run(ctx context.Context) error {
 	}
 
 	// create client conn
-	conn, err := dsc.NewConn(&cmd.Config)
+	conn, err := cmd.Config.Connect(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/clients/authorizer/client.go
+++ b/pkg/cli/clients/authorizer/client.go
@@ -16,45 +16,17 @@ import (
 )
 
 type Config struct {
-	Host     string `flag:"host" short:"H" default:"${authorizer_svc}" env:"TOPAZ_AUTHORIZER_SVC" help:"authorizer service address"`
-	APIKey   string `flag:"api-key" short:"k" default:"${authorizer_key}" env:"TOPAZ_AUTHORIZER_KEY" help:"authorizer API key"`
-	Token    string `flag:"token" default:"${authorizer_token}" env:"TOPAZ_AUTHORIZER_TOKEN" help:"authorizer OAuth2.0 token" hidden:""`
-	Insecure bool   `flag:"insecure" short:"i" default:"${insecure}" env:"TOPAZ_INSECURE" help:"skip TLS verification"`
-	TenantID string `flag:"tenant-id" help:"" default:"${tenant_id}" env:"ASERTO_TENANT_ID" `
+	Host     string            `flag:"host" short:"H" default:"${authorizer_svc}" env:"TOPAZ_AUTHORIZER_SVC" help:"authorizer service address"`
+	APIKey   string            `flag:"api-key" short:"k" default:"${authorizer_key}" env:"TOPAZ_AUTHORIZER_KEY" help:"authorizer API key"`
+	Token    string            `flag:"token" default:"${authorizer_token}" env:"TOPAZ_AUTHORIZER_TOKEN" help:"authorizer OAuth2.0 token" hidden:""`
+	Insecure bool              `flag:"insecure" short:"i" default:"${insecure}" env:"TOPAZ_INSECURE" help:"skip TLS verification"`
+	TenantID string            `flag:"tenant-id" help:"" default:"${tenant_id}" env:"ASERTO_TENANT_ID" `
+	Headers  map[string]string `flag:"headers" env:"TOPAZ_AUTHORIZER_HEADERS" help:"additional headers to send to the authorizer service"`
 }
 
 type Client struct {
 	conn       *grpc.ClientConn
 	Authorizer az2.AuthorizerClient
-}
-
-func NewConn(cfg *Config) (*grpc.ClientConn, error) {
-	if cfg.Host == "" {
-		return nil, fmt.Errorf("no host specified")
-	}
-
-	if err := cfg.validate(); err != nil {
-		return nil, err
-	}
-
-	opts := []client.ConnectionOption{
-		client.WithAddr(cfg.Host),
-		client.WithInsecure(cfg.Insecure),
-	}
-
-	if cfg.APIKey != "" {
-		opts = append(opts, client.WithAPIKeyAuth(cfg.APIKey))
-	}
-
-	if cfg.Token != "" {
-		opts = append(opts, client.WithTokenAuth(cfg.Token))
-	}
-
-	if cfg.TenantID != "" {
-		opts = append(opts, client.WithTenantID(cfg.TenantID))
-	}
-
-	return client.NewConnection(opts...)
 }
 
 func New(conn *grpc.ClientConn) *Client {
@@ -65,7 +37,7 @@ func New(conn *grpc.ClientConn) *Client {
 }
 
 func NewClient(c *cc.CommonCtx, cfg *Config) (*Client, error) {
-	conn, err := NewConn(cfg)
+	conn, err := cfg.Connect(c.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -73,9 +45,19 @@ func NewClient(c *cc.CommonCtx, cfg *Config) (*Client, error) {
 	return New(conn), nil
 }
 
-func (cfg *Config) validate() error {
-	ctx := context.Background()
+func (cfg *Config) Connect(ctx context.Context) (*grpc.ClientConn, error) {
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("no host specified")
+	}
 
+	if err := cfg.validate(ctx); err != nil {
+		return nil, err
+	}
+
+	return cfg.connect()
+}
+
+func (cfg *Config) validate(ctx context.Context) error {
 	tlsConf, err := grpcurl.ClientTLSConfig(cfg.Insecure, "", "", "")
 	if err != nil {
 		return errors.Wrap(err, "failed to create TLS config")
@@ -96,4 +78,22 @@ func (cfg *Config) validate() error {
 	}
 
 	return nil
+}
+
+func (cfg *Config) connect() (*grpc.ClientConn, error) {
+	clientCfg := &client.Config{
+		Address:  cfg.Host,
+		Insecure: cfg.Insecure,
+		APIKey:   cfg.APIKey,
+		Token:    cfg.Token,
+		TenantID: cfg.TenantID,
+		Headers:  cfg.Headers,
+	}
+
+	opts, err := clientCfg.ToConnectionOptions(client.NewDialOptionsProvider())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create directory connection options")
+	}
+
+	return client.NewConnection(opts...)
 }

--- a/pkg/cli/clients/directory/client.go
+++ b/pkg/cli/clients/directory/client.go
@@ -21,11 +21,12 @@ import (
 )
 
 type Config struct {
-	Host     string `flag:"host" short:"H" default:"${directory_svc}" env:"TOPAZ_DIRECTORY_SVC" help:"directory service address"`
-	APIKey   string `flag:"api-key" short:"k" default:"${directory_key}" env:"TOPAZ_DIRECTORY_KEY" help:"directory API key"`
-	Token    string `flag:"token" default:"${directory_token}" env:"TOPAZ_DIRECTORY_TOKEN" help:"directory OAuth2.0 token" hidden:""`
-	Insecure bool   `flag:"insecure" short:"i" default:"${insecure}" env:"TOPAZ_INSECURE" help:"skip TLS verification"`
-	TenantID string `flag:"tenant-id" help:"" default:"${tenant_id}" env:"ASERTO_TENANT_ID" `
+	Host     string            `flag:"host" short:"H" default:"${directory_svc}" env:"TOPAZ_DIRECTORY_SVC" help:"directory service address"`
+	APIKey   string            `flag:"api-key" short:"k" default:"${directory_key}" env:"TOPAZ_DIRECTORY_KEY" help:"directory API key"`
+	Token    string            `flag:"token" default:"${directory_token}" env:"TOPAZ_DIRECTORY_TOKEN" help:"directory OAuth2.0 token" hidden:""`
+	Insecure bool              `flag:"insecure" short:"i" default:"${insecure}" env:"TOPAZ_INSECURE" help:"skip TLS verification"`
+	TenantID string            `flag:"tenant-id" help:"" default:"${tenant_id}" env:"ASERTO_TENANT_ID" `
+	Headers  map[string]string `flag:"headers" env:"TOPAZ_DIRECTORY_HEADERS" help:"additional headers to send to the directory service"`
 }
 
 type Client struct {
@@ -36,35 +37,6 @@ type Client struct {
 	Importer  dsi3.ImporterClient
 	Exporter  dse3.ExporterClient
 	Assertion dsa3.AssertionClient
-}
-
-func NewConn(cfg *Config) (*grpc.ClientConn, error) {
-	if cfg.Host == "" {
-		return nil, fmt.Errorf("no host specified")
-	}
-
-	if err := cfg.validate(); err != nil {
-		return nil, err
-	}
-
-	opts := []client.ConnectionOption{
-		client.WithAddr(cfg.Host),
-		client.WithInsecure(cfg.Insecure),
-	}
-
-	if cfg.APIKey != "" {
-		opts = append(opts, client.WithAPIKeyAuth(cfg.APIKey))
-	}
-
-	if cfg.Token != "" {
-		opts = append(opts, client.WithTokenAuth(cfg.Token))
-	}
-
-	if cfg.TenantID != "" {
-		opts = append(opts, client.WithTenantID(cfg.TenantID))
-	}
-
-	return client.NewConnection(opts...)
 }
 
 func New(conn *grpc.ClientConn) *Client {
@@ -80,7 +52,7 @@ func New(conn *grpc.ClientConn) *Client {
 }
 
 func NewClient(c *cc.CommonCtx, cfg *Config) (*Client, error) {
-	conn, err := NewConn(cfg)
+	conn, err := cfg.Connect(c.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -88,9 +60,19 @@ func NewClient(c *cc.CommonCtx, cfg *Config) (*Client, error) {
 	return New(conn), nil
 }
 
-func (cfg *Config) validate() error {
-	ctx := context.Background()
+func (cfg *Config) Connect(ctx context.Context) (*grpc.ClientConn, error) {
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("no host specified")
+	}
 
+	if err := cfg.validate(ctx); err != nil {
+		return nil, err
+	}
+
+	return cfg.connect()
+}
+
+func (cfg *Config) validate(ctx context.Context) error {
 	tlsConf, err := grpcurl.ClientTLSConfig(cfg.Insecure, "", "", "")
 	if err != nil {
 		return errors.Wrap(err, "failed to create TLS config")
@@ -111,4 +93,22 @@ func (cfg *Config) validate() error {
 	}
 
 	return nil
+}
+
+func (cfg *Config) connect() (*grpc.ClientConn, error) {
+	clientCfg := &client.Config{
+		Address:  cfg.Host,
+		Insecure: cfg.Insecure,
+		APIKey:   cfg.APIKey,
+		Token:    cfg.Token,
+		TenantID: cfg.TenantID,
+		Headers:  cfg.Headers,
+	}
+
+	opts, err := clientCfg.ToConnectionOptions(client.NewDialOptionsProvider())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create directory connection options")
+	}
+
+	return client.NewConnection(opts...)
 }

--- a/plugins/edge/plugin.go
+++ b/plugins/edge/plugin.go
@@ -315,17 +315,17 @@ func (p *Plugin) exec(ctx context.Context, ds *directory.Directory, conn *grpc.C
 }
 
 func (p *Plugin) remoteDirectoryClient() (*grpc.ClientConn, error) {
-	opts := []client.ConnectionOption{
-		client.WithAddr(p.config.Addr),
-		client.WithInsecure(p.config.Insecure),
+	cfg := &client.Config{
+		Address:  p.config.Addr,
+		Insecure: p.config.Insecure,
+		APIKey:   p.config.APIKey,
+		TenantID: p.config.TenantID,
+		Headers:  p.topazConfig.DirectoryResolver.Headers,
 	}
 
-	if p.config.APIKey != "" {
-		opts = append(opts, client.WithAPIKeyAuth(p.config.APIKey))
-	}
-
-	if p.config.TenantID != "" {
-		opts = append(opts, client.WithTenantID(p.config.TenantID))
+	opts, err := cfg.ToConnectionOptions(client.NewDialOptionsProvider())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create connection options")
 	}
 
 	conn, err := client.NewConnection(opts...)


### PR DESCRIPTION
This gives users the ability to configure topaz to include additional headers (gRPC metadata) in all directory calls.
The remote_directory config value is alread an aserto.Config, which has a Headers field. This commit simply wires that into the underlying connection.

It also gives the same ability to the directory and authorizer CLI commands. For example:

```sh
topaz ds get manifest --headers "foo=bar,a=b"
```

or (same semantics):
```sh
topaz ds get manifest --headers "foo=bar" --headers "a=b"
```