### PR TITLE
Fix SearviceHealthStatus

### DIFF
--- a/pkg/cli/cmd/templates/install.go
+++ b/pkg/cli/cmd/templates/install.go
@@ -111,7 +111,9 @@ func (cmd *InstallTemplateCmd) installTemplate(c *cc.CommonCtx, tmpl *template) 
 		fmt.Fprintln(c.StdErr(), "Please change to using the new TOPAZ_DB_DIR and TOPAZ_CERTS_DIR environment variables.")
 	}
 	addr, _ := cfg.HealthService()
-	if !cc.ServiceHealthStatus(addr, "model") {
+	if health, err := cc.ServiceHealthStatus(c.Context, addr, "model"); err != nil {
+		return fmt.Errorf("unable to check health status: %w", err)
+	} else if !health {
 		return fmt.Errorf("gRPC endpoint not SERVING")
 	}
 	if model, ok := cfg.Configuration.APIConfig.Services["model"]; !ok {


### PR DESCRIPTION
It was failing to connect due to an SSL issue but was using deprecated grpc calls and the `google.golang.org/grpc/credentials/insecure` package which I don't think we use anywhere else.

This PR uses go-aserto to establish the connection to the health service.