### PR TITLE
Allow templates to use local policies

### DIFF
--- a/pkg/cc/config/generator.go
+++ b/pkg/cc/config/generator.go
@@ -22,8 +22,8 @@ func (g *Generator) WithVersion(version int) *Generator {
 	return g
 }
 
-func (g *Generator) WithLocalPolicyImage(image string) *Generator {
-	g.LocalPolicyImage = image
+func (g *Generator) WithLocalPolicy(local bool) *Generator {
+	g.LocalPolicy = local
 	return g
 }
 

--- a/pkg/cc/config/templates.go
+++ b/pkg/cc/config/templates.go
@@ -2,10 +2,10 @@ package config
 
 type templateParams struct {
 	Version           int
-	LocalPolicyImage  string
 	PolicyName        string
 	Resource          string
 	Authorization     string
+	LocalPolicy       bool
 	EdgeDirectory     bool
 	SeedMetadata      bool
 	EnableDirectoryV2 bool
@@ -34,7 +34,7 @@ opa:
   graceful_shutdown_period_seconds: 2
   # max_plugin_wait_time_seconds: 30 set as default
   local_bundles:
-    local_policy_image: {{ .LocalPolicyImage }}
+    local_policy_image: {{ .Resource }}
     watch: true
     skip_verification: true
 `
@@ -148,8 +148,8 @@ jwt:
 # authentication configuration
 auth:
   api_keys:
-    # "<API key>": <Identity>  
-    # "<Password>": <Identity>  
+    # "<API key>": <Identity>
+    # "<Password>": <Identity>
   options:
     default:
       enable_api_key: false
@@ -457,7 +457,7 @@ api:
         read_header_timeout: 2s
         write_timeout: 2s
         idle_timeout: 30s
-  
+
     authorizer:
       needs:
         - reader

--- a/pkg/cli/cmd/configure/new.go
+++ b/pkg/cli/cmd/configure/new.go
@@ -13,13 +13,18 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	FromRemote = "remote"
+	FromLocal  = "local"
+)
+
 type NewConfigCmd struct {
 	Name             ConfigName `short:"n" help:"config name"`
 	Resource         string     `short:"r" help:"policy uri (e.g. ghcr.io/org/policy:tag)"`
-	Local            bool       `help:"load the policy image from the local registry"`
+	From             string     `enum:"remote,local" default:"remote" help:"load policy from remote or local image"`
 	Stdout           bool       `short:"p" help:"print to stdout" default:"false"`
 	EdgeDirectory    bool       `short:"d" help:"enable edge directory" default:"false"`
-	Force            bool       `flag:"" default:"false" short:"f" required:"false" help:"skip confirmation prompt"`
+	Force            bool       `short:"f" flag:"" default:"false" required:"false" help:"skip confirmation prompt"`
 	LocalPolicyImage string     `short:"l" help:"[deprecated: use --local instead] local policy image name"`
 }
 
@@ -44,7 +49,7 @@ func (cmd *NewConfigCmd) Run(c *cc.CommonCtx) error {
 	}
 
 	// Backward-compatibility with deprecated LocalPolicyImage option.
-	resource, local := cmd.Resource, cmd.Local
+	resource, local := cmd.Resource, cmd.From == FromLocal
 	if cmd.LocalPolicyImage != "" {
 		resource, local = cmd.LocalPolicyImage, true
 	}

--- a/pkg/cli/cmd/templates/install.go
+++ b/pkg/cli/cmd/templates/install.go
@@ -175,9 +175,13 @@ func (cmd *InstallTemplateCmd) prepareTopaz(c *cc.CommonCtx, tmpl *template, cus
 	// 2 - topaz config new - generate a new configuration based on the requirements of the template
 	if !cmd.NoConfigure {
 		command := configure.NewConfigCmd{
-			Name:     configure.ConfigName(name),
-			Resource: tmpl.Assets.Policy.Resource,
-			Force:    true,
+			Name:  configure.ConfigName(name),
+			Force: true,
+		}
+		if tmpl.Assets.Policy.Local {
+			command.LocalPolicyImage = tmpl.Assets.Policy.Resource
+		} else {
+			command.Resource = tmpl.Assets.Policy.Resource
 		}
 		if err := command.Run(c); err != nil {
 			return err

--- a/pkg/cli/cmd/templates/install.go
+++ b/pkg/cli/cmd/templates/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aserto-dev/topaz/pkg/cli/cmd/configure"
 	"github.com/aserto-dev/topaz/pkg/cli/cmd/directory"
 	"github.com/aserto-dev/topaz/pkg/cli/cmd/topaz"
+	"github.com/samber/lo"
 )
 
 type InstallTemplateCmd struct {
@@ -177,7 +178,7 @@ func (cmd *InstallTemplateCmd) prepareTopaz(c *cc.CommonCtx, tmpl *template, cus
 		command := configure.NewConfigCmd{
 			Name:     configure.ConfigName(name),
 			Resource: tmpl.Assets.Policy.Resource,
-			Local:    tmpl.Assets.Policy.Local,
+			From:     lo.Ternary(tmpl.Assets.Policy.Local, configure.FromLocal, configure.FromRemote),
 			Force:    true,
 		}
 		if err := command.Run(c); err != nil {

--- a/pkg/cli/cmd/templates/install.go
+++ b/pkg/cli/cmd/templates/install.go
@@ -175,13 +175,10 @@ func (cmd *InstallTemplateCmd) prepareTopaz(c *cc.CommonCtx, tmpl *template, cus
 	// 2 - topaz config new - generate a new configuration based on the requirements of the template
 	if !cmd.NoConfigure {
 		command := configure.NewConfigCmd{
-			Name:  configure.ConfigName(name),
-			Force: true,
-		}
-		if tmpl.Assets.Policy.Local {
-			command.LocalPolicyImage = tmpl.Assets.Policy.Resource
-		} else {
-			command.Resource = tmpl.Assets.Policy.Resource
+			Name:     configure.ConfigName(name),
+			Resource: tmpl.Assets.Policy.Resource,
+			Local:    tmpl.Assets.Policy.Local,
+			Force:    true,
 		}
 		if err := command.Run(c); err != nil {
 			return err

--- a/pkg/cli/cmd/templates/template.go
+++ b/pkg/cli/cmd/templates/template.go
@@ -46,6 +46,7 @@ type template struct {
 		Policy   struct {
 			Name     string `json:"name"`
 			Resource string `json:"resource"`
+			Local    bool   `json:"local"`
 		} `json:"policy,omitempty"`
 		IdentityData []string `json:"idp_data,omitempty"`
 		DomainData   []string `json:"domain_data,omitempty"`


### PR DESCRIPTION
This makes it possible to use `topaz templates install` with a policy image that has been built locally but not pushed to a remote registry.

It is especially useful in policy repos when testing local changes or validating pull requests in CI.

In addition, there are some changes to the `config new` command:
* A new `--from [remote|local]` enum option is introduced. If `local`, topaz loads the image specified in `--resource` from the local policy registry. The default is `remote`.
* The `--local-policy-image` option is deprecated (but still implemented for backward-compatibility).