### PR TITLE
Add decision assertions

### DIFF
--- a/assets/api-auth.json
+++ b/assets/api-auth.json
@@ -16,7 +16,8 @@
             "api-auth/api-auth-relations.json"
         ],
         "assertions": [
-            "api-auth/test/api-auth_assertions.json"
+            "api-auth/test/api-auth_assertions.json",
+            "api-auth/test/api-auth_decision.json"
         ]
     }
 }

--- a/assets/api-auth/test/api-auth_decisions.json
+++ b/assets/api-auth/test/api-auth_decisions.json
@@ -1,0 +1,788 @@
+{
+  "assertions": [
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:DELETE:/v1/todos/{todoId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:DELETE:/v1/todos/{todoId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:DELETE:/v1/todos/{todoId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:DELETE:/v1/todos/{todoId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:DELETE:/v1/todos/{todoId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:GET:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:GET:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:GET:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:GET:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:GET:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:POST:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:POST:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:POST:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:POST:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "todo:POST:/v1/todos",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick-and-morty:GET:/v1/characters",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick-and-morty:GET:/v1/characters",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick-and-morty:GET:/v1/characters",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick-and-morty:GET:/v1/characters",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick-and-morty:GET:/v1/characters",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:GET:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:GET:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:GET:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:GET:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:GET:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:POST:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:POST:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:POST:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:POST:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:POST:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:DELETE:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:DELETE:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:DELETE:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:DELETE:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "petstore:DELETE:/pet/{petId}",
+          "object_type": "endpoint",
+          "relation": "can_invoke"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    }
+  ]
+}

--- a/assets/gdrive.json
+++ b/assets/gdrive.json
@@ -16,7 +16,8 @@
             "gdrive/gdrive_relations.json"
         ],
         "assertions": [
-            "gdrive/test/gdrive_assertions.json"
+            "gdrive/test/gdrive_assertions.json",
+            "gdrive/test/gdrive_decisions.json"
         ]
     }
 }

--- a/assets/gdrive/test/gdrive_decisions.json
+++ b/assets/gdrive/test/gdrive_decisions.json
@@ -1,0 +1,4200 @@
+{
+  "assertions": [
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "root",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "summer",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "jerry",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared",
+          "object_type": "folder",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "secrets",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "groceries",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "rick.inventions",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_share"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "morty.shared.notes",
+          "object_type": "doc",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    }
+  ]
+}

--- a/assets/github.json
+++ b/assets/github.json
@@ -16,7 +16,8 @@
             "github/github_relations.json"
         ],
         "assertions": [
-            "github/test/github_assertions.json"
+            "github/test/github_assertions.json",
+            "github/test/github_decisions.json"
         ]
     }
 }

--- a/assets/github/test/github_decisions.json
+++ b/assets/github/test/github_decisions.json
@@ -1,0 +1,253 @@
+{
+  "assertions": [
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_triage"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_triage"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.budget",
+          "object_type": "repo",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel.missions",
+          "object_type": "repo",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel.missions",
+          "object_type": "repo",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel.missions",
+          "object_type": "repo",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    }
+  ]
+}

--- a/assets/multi-tenant.json
+++ b/assets/multi-tenant.json
@@ -16,7 +16,8 @@
             "multi-tenant/multi-tenant-relations.json"
         ],
         "assertions": [
-            "multi-tenant/test/multi-tenant_assertions.json"
+            "multi-tenant/test/multi-tenant_assertions.json",
+            "multi-tenant/test/multi-tenant_decisions.json"
         ]
     }
 }

--- a/assets/multi-tenant/test/multi-tenant_decisions.json
+++ b/assets/multi-tenant/test/multi-tenant_decisions.json
@@ -1,0 +1,5211 @@
+{
+  "assertions": [
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "can_create_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "can_create_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "can_create_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "can_create_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "can_create_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "system",
+          "object_type": "system",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "editor"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "viewer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_administer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_edit"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_view"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_manage_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_list_members"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_leave_tenant"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_create_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_delete_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_write_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "can_read_resources"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel-adventures",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "owner"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "reader"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_delete"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_write"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths-budget",
+          "object_type": "resource",
+          "relation": "can_read"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "system",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "citadel",
+          "object_type": "tenant",
+          "relation": "system"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "system",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "tenant",
+          "relation": "system"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    }
+  ]
+}

--- a/assets/simple-rbac.json
+++ b/assets/simple-rbac.json
@@ -15,6 +15,9 @@
             "simple-rbac/simple-rbac_objects.json",
             "simple-rbac/simple-rbac_relations.json"
         ],
-        "assertions": []
+        "assertions": [
+            "simple-rbac/assertions.json",
+            "simple-rbac/decisions.json"
+        ]
     }
 }

--- a/assets/simple-rbac/assertions.json
+++ b/assets/simple-rbac/assertions.json
@@ -1,12 +1,12 @@
 {
     "assertions": [
         {
-            "check_relation": {
+            "check": {
                 "subject_type": "user",
                 "subject_id": "rick@the-citadel.com",
+                "relation": "member",
                 "object_type": "group",
-                "object_id": "admin",
-                "relation": "member"
+                "object_id": "admin"
             },
             "expected": true
         }

--- a/assets/simple-rbac/decisions.json
+++ b/assets/simple-rbac/decisions.json
@@ -1,0 +1,27 @@
+{
+  "assertions": [
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "admin",
+          "object_type": "group",
+          "relation": "member"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    }
+  ]
+}

--- a/assets/slack.json
+++ b/assets/slack.json
@@ -16,7 +16,8 @@
           "slack/slack_relations.json"
       ],
       "assertions": [
-          "slack/test/slack_assertions.json"
+          "slack/test/slack_assertions.json",
+          "slack/test/slack_decisions.json"
       ]
   }
 }

--- a/assets/slack/test/slack_decisions.json
+++ b/assets/slack/test/slack_decisions.json
@@ -1,0 +1,162 @@
+{
+  "assertions": [
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "rick@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "workspace",
+          "relation": "channels_admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "jerry@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths",
+          "object_type": "workspace",
+          "relation": "channels_admin"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.citadel",
+          "object_type": "channel",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.citadel",
+          "object_type": "channel",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "morty@the-citadel.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.gossip",
+          "object_type": "channel",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "beth@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.general",
+          "object_type": "channel",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      },
+      "expected": true
+    },
+    {
+      "check_decision": {
+        "policy_context": {
+          "path": "rebac.check",
+          "decisions": [
+            "allowed"
+          ]
+        },
+        "identity_context": {
+          "identity": "summer@the-smiths.com",
+          "type": "IDENTITY_TYPE_SUB"
+        },
+        "resource_context": {
+          "object_id": "smiths.general",
+          "object_type": "channel",
+          "relation": "writer"
+        },
+        "policy_instance": {
+          "name": "policy-rebac"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add decision assertions to templates that use policy-rebac.
The decision assertions are generated from the directory check assertions using check2decision.
