### PR TITLE
Edge health

### DIFF
--- a/pkg/app/topaz.go
+++ b/pkg/app/topaz.go
@@ -100,11 +100,6 @@ func (e *Topaz) Start() error {
 		for serviceName := range e.Configuration.APIConfig.Services {
 			e.Manager.HealthServer.SetServiceStatus(serviceName, grpc_health_v1.HealthCheckResponse_SERVING)
 		}
-
-		// register phony sync service with status NOT_SERVING
-		service, servingStatus := "sync", grpc_health_v1.HealthCheckResponse_NOT_SERVING
-		e.Manager.HealthServer.Server.SetServingStatus(service, servingStatus)
-		e.Logger.Info().Str("component", "edge.plugin").Str("service", service).Str("status", servingStatus.String()).Msg("health")
 	}
 
 	return nil

--- a/plugins/edge/factory.go
+++ b/plugins/edge/factory.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/aserto-dev/topaz/pkg/app"
 	topaz "github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/aserto-dev/topaz/plugins/noop"
 	"github.com/mitchellh/mapstructure"
@@ -13,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type PluginFactory struct {
@@ -41,6 +43,10 @@ func (f PluginFactory) New(m *plugins.Manager, config interface{}) plugins.Plugi
 			Name:    PluginName,
 		}
 	}
+
+	service, servingStatus := "sync", grpc_health_v1.HealthCheckResponse_NOT_SERVING
+	app.SetServiceStatus(f.logger, service, servingStatus)
+	f.logger.Info().Str("component", "edge.plugin").Str("service", service).Str("status", servingStatus.String()).Msg("health")
 
 	return newEdgePlugin(f.logger, cfg, f.cfg, m)
 }

--- a/plugins/edge/plugin.go
+++ b/plugins/edge/plugin.go
@@ -42,6 +42,8 @@ type Config struct {
 	Insecure          bool          `json:"insecure"`
 	SessionID         string        `json:"session_id,omitempty"`
 	ConnectionTimeout time.Duration `json:"-"`
+	// Deprecated: No longer used.
+	PageSize int `json:"page_size,omitempty"`
 }
 
 type Plugin struct {


### PR DESCRIPTION
Only report health status for the edge plugin if it is enabled.

Also bring back the edge PageSize config option because the discovery service still includes it in its responses.
It needs to be removed there first.