### PR TITLE
Revert "Only report edge plugin health if sync is enabled."

### DIFF
--- a/pkg/app/topaz.go
+++ b/pkg/app/topaz.go
@@ -100,6 +100,11 @@ func (e *Topaz) Start() error {
 		for serviceName := range e.Configuration.APIConfig.Services {
 			e.Manager.HealthServer.SetServiceStatus(serviceName, grpc_health_v1.HealthCheckResponse_SERVING)
 		}
+
+		// register phony sync service with status NOT_SERVING
+		service, servingStatus := "sync", grpc_health_v1.HealthCheckResponse_NOT_SERVING
+		e.Manager.HealthServer.Server.SetServingStatus(service, servingStatus)
+		e.Logger.Info().Str("component", "edge.plugin").Str("service", service).Str("status", servingStatus.String()).Msg("health")
 	}
 
 	return nil

--- a/plugins/edge/factory.go
+++ b/plugins/edge/factory.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/aserto-dev/topaz/pkg/app"
 	topaz "github.com/aserto-dev/topaz/pkg/cc/config"
 	"github.com/aserto-dev/topaz/plugins/noop"
 	"github.com/mitchellh/mapstructure"
@@ -14,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type PluginFactory struct {
@@ -43,10 +41,6 @@ func (f PluginFactory) New(m *plugins.Manager, config interface{}) plugins.Plugi
 			Name:    PluginName,
 		}
 	}
-
-	service, servingStatus := "sync", grpc_health_v1.HealthCheckResponse_NOT_SERVING
-	app.SetServiceStatus(f.logger, service, servingStatus)
-	f.logger.Info().Str("component", "edge.plugin").Str("service", service).Str("status", servingStatus.String()).Msg("health")
 
 	return newEdgePlugin(f.logger, cfg, f.cfg, m)
 }


### PR DESCRIPTION
This reverts commit 7a6f2ee154d6905272435fcb0a71d54b14ddc19c.

It was a mistake to omit the "sync" health status when the edge plugin isn't enabled. The plugin can be enabled and disabled dynamically through discovery calls and it's better to always include its status in the health service.

I originally made the change because it looked like the kubernetes startup probe was getting back NOT_SERVING responses, but I tested it again with the change in this PR and the overall pod health is reported as healthy even if the "sync" service's status is NOT_SERVING.