### PR TITLE
generate SBOM by GOOS and GOARCH

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -210,7 +210,7 @@ sboms:
   # https://goreleaser.com/customization/sbom/
   - id: default
     documents:
-      - "${artifact}.spdx.sbom.json"
+      - "${artifact}-{{.Os}}-{{.Arch}}.spdx.sbom.json"
     cmd: syft
     args:
       - "$artifact"


### PR DESCRIPTION
Generate SBOM artifacts by `GOOS` and `GOARCH`, to prevent collisions when uploading release.