### PR TITLE
fix gtw panic

### DIFF
--- a/pkg/service/builder/service.go
+++ b/pkg/service/builder/service.go
@@ -25,7 +25,7 @@ type Service struct {
 	Config   *API
 	Server   *grpc.Server
 	Listener net.Listener
-	Gateway  Gateway
+	Gateway  *Gateway
 	Started  chan bool
 	Cleanup  []func()
 }

--- a/pkg/service/builder/service_manager.go
+++ b/pkg/service/builder/service_manager.go
@@ -159,23 +159,25 @@ func (s *ServiceManager) StartServers(ctx context.Context) error {
 				return grpcServer.Serve(listener)
 			})
 
-			httpServer := serverDetails.Gateway
-			if httpServer.Server != nil {
-				s.errGroup.Go(func() error {
-					s.logger.Info().Msgf("Starting %s gateway server", httpServer.Server.Addr)
-					if httpServer.Certs.HasCert() {
-						err := httpServer.Server.ListenAndServeTLS(httpServer.Certs.Cert, httpServer.Certs.Key)
-						if err != nil {
-							return err
+			if serverDetails.Gateway != nil {
+				httpServer := serverDetails.Gateway
+				if httpServer.Server != nil {
+					s.errGroup.Go(func() error {
+						s.logger.Info().Msgf("Starting %s gateway server", httpServer.Server.Addr)
+						if httpServer.Certs.HasCert() {
+							err := httpServer.Server.ListenAndServeTLS(httpServer.Certs.Cert, httpServer.Certs.Key)
+							if err != nil {
+								return err
+							}
+						} else {
+							err := httpServer.Server.ListenAndServe()
+							if err != nil {
+								return err
+							}
 						}
-					} else {
-						err := httpServer.Server.ListenAndServe()
-						if err != nil {
-							return err
-						}
-					}
-					return nil
-				})
+						return nil
+					})
+				}
 			}
 
 			serverDetails.Started <- true // send started information.


### PR DESCRIPTION
Fix panic in the console gateway when running in NoTLS mode
* make gateway a pointer
* return nil gateway on error
* check for nil gateway instance in StartServers