### PR TITLE
fix templates install issues

### DIFF
--- a/pkg/cli/cc/health.go
+++ b/pkg/cli/cc/health.go
@@ -9,7 +9,7 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
-const rpcTimeout = time.Second * 30
+const rpcTimeout = time.Second * 10
 
 // ServiceHealthStatus adopted from grpc-health-probe cli implementation
 // https://github.com/grpc-ecosystem/grpc-health-probe/blob/master/main.go.

--- a/pkg/cli/cmd/templates/install.go
+++ b/pkg/cli/cmd/templates/install.go
@@ -122,6 +122,7 @@ func (cmd *InstallTemplateCmd) installTemplate(c *cc.CommonCtx, tmpl *template) 
 		CACertPath:     "",
 		Insecure:       false,
 		NoTLS:          true,
+		NoProxy:        false,
 	}
 
 	if healthy, err := cc.ServiceHealthStatus(c.Context, healthCfg, "model"); err != nil {
@@ -375,20 +376,24 @@ func (i *tmplInstaller) runTemplateTests() error {
 			Desc:    "on-error",
 		},
 		&azc.Config{
-			Host:     cc.AuthorizerSvc(),
-			APIKey:   i.cfg.APIKey,
-			Token:    i.cfg.Token,
-			Insecure: i.cfg.Insecure,
-			TenantID: i.cfg.TenantID,
-			Headers:  i.cfg.Headers,
+			Host:      cc.AuthorizerSvc(),
+			APIKey:    i.cfg.APIKey,
+			Token:     i.cfg.Token,
+			Insecure:  i.cfg.Insecure,
+			Plaintext: i.cfg.Plaintext,
+			TenantID:  i.cfg.TenantID,
+			Headers:   i.cfg.Headers,
+			Timeout:   i.cfg.Timeout,
 		},
 		&dsc.Config{
-			Host:     i.cfg.Host,
-			APIKey:   i.cfg.APIKey,
-			Token:    i.cfg.Token,
-			Insecure: i.cfg.Insecure,
-			TenantID: i.cfg.TenantID,
-			Headers:  i.cfg.Headers,
+			Host:      i.cfg.Host,
+			APIKey:    i.cfg.APIKey,
+			Token:     i.cfg.Token,
+			Insecure:  i.cfg.Insecure,
+			Plaintext: i.cfg.Plaintext,
+			TenantID:  i.cfg.TenantID,
+			Headers:   i.cfg.Headers,
+			Timeout:   i.cfg.Timeout,
 		},
 	)
 	if err != nil {

--- a/pkg/service/builder/service_factory.go
+++ b/pkg/service/builder/service_factory.go
@@ -110,7 +110,7 @@ func (f *ServiceFactory) prepareGateway(config *API, gatewayOpts *GatewayOptions
 	runtimeMux := f.gatewayMux(config.Gateway.AllowedHeaders, gatewayOpts.ErrorHandler)
 
 	opts := []grpc.DialOption{}
-	if config.GRPC.Certs.HasCert() {
+	if config.GRPC.Certs.HasCA() {
 		tlsCreds, err := config.GRPC.Certs.ClientCredentials(true)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get TLS credentials")


### PR DESCRIPTION
* fix the `deadline context exceeded` after import data
  * this was caused by the new timeout duration value in `client.Config` not being passed alone to the command handler executing the tests.
* fix directory gateway not getting started
  * this was caused by the `mapToGRPCPorts` func not being deterministic, the first directory gRPC service in the `api` map was setting the state, when this is an `exporter` or `importer` the gateway definition is empty, resulting in the gateway not to get started. As the information was retrieved from a map, the behavior was undeterministic, based on the order of the map entries.
* reduced the health service check wait time from 30 to 10 seconds.
* update service factory to detect HasCA() instead of HasCert() which is more correctly reflecting that the client connection from the gateway to the gRPC service only needs a CA cert.