### PR TITLE
go-edge-ds v0.33.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aserto-dev/go-aserto v0.33.6
 	github.com/aserto-dev/go-authorizer v0.20.13
 	github.com/aserto-dev/go-directory v0.33.4
-	github.com/aserto-dev/go-edge-ds v0.33.7
+	github.com/aserto-dev/go-edge-ds v0.33.8
 	github.com/aserto-dev/go-grpc v0.9.4
 	github.com/aserto-dev/go-topaz-ui v0.1.17
 	github.com/aserto-dev/header v0.0.10
@@ -56,7 +56,7 @@ require (
 	github.com/rivo/tview v0.0.0-20241227133733-17b7edb88c57
 	github.com/rs/cors v1.11.1
 	github.com/rs/zerolog v1.33.0
-	github.com/samber/lo v1.49.0
+	github.com/samber/lo v1.49.1
 	github.com/slok/go-http-metrics v0.13.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -70,8 +70,8 @@ require (
 )
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.3-20241127180247-a33202765966.1 // indirect
-	cel.dev/expr v0.19.1 // indirect
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.4-20241127180247-a33202765966.1 // indirect
+	cel.dev/expr v0.19.2 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -106,7 +106,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/cel-go v0.22.1 // indirect
+	github.com/google/cel-go v0.23.1 // indirect
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0 // indirect
@@ -182,7 +182,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
+	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/term v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.3-20241127180247-a33202765966.1 h1:cQZXKoQ+eB0kykzfJe80RP3nc+3PWbbBrUBm8XNYAQY=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.3-20241127180247-a33202765966.1/go.mod h1:6VPKM8zbmgf9qsmkmKeH49a36Vtmidw3rG53B5mTenc=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.4-20241127180247-a33202765966.1 h1:yeaeyw0RQUe009ebxBQ3TsqBPptiNEGsiS10t+8Htuo=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.4-20241127180247-a33202765966.1/go.mod h1:novQBstnxcGpfKf8qGRATqn1anQKwMJIbH5Q581jibU=
 cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
 cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.19.2 h1:V354PbqIXr9IQdwy4SYA4xa0HXaWq1BUPAGzugBY5V4=
+cel.dev/expr v0.19.2/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -400,6 +404,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/agnivade/levenshtein v1.2.0 h1:U9L4IOT0Y3i0TIlUIDJ7rVUziKi/zPbrJGaFrtYH3SY=
 github.com/agnivade/levenshtein v1.2.0/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
+github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
+github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.6.1 h1:/7bVimARU3uxPD0hbryPE8qWrS3Oz3kPQoxA/H2NKG8=
@@ -431,6 +437,8 @@ github.com/aserto-dev/go-directory v0.33.4 h1:LhAL0RGKB7L2dm4hjAYVeuUhsu+EreYTUv
 github.com/aserto-dev/go-directory v0.33.4/go.mod h1:p0wsjtpBBW2huPDgi6I8OqfhwJWyMRqJHlwPVb3kTSM=
 github.com/aserto-dev/go-edge-ds v0.33.7 h1:eGu5SnMZhFuz4Ym6wAWucGU78br90u89lSPp/Sf2rsI=
 github.com/aserto-dev/go-edge-ds v0.33.7/go.mod h1:f7mAjPSBUa9wXYUdk++JeXav9Z2T+/bwvMmdGz7pxCw=
+github.com/aserto-dev/go-edge-ds v0.33.8 h1:rXBXb16ZWbMWnj+Y7OVNFDpogu0bCCxds+EeUy5veIg=
+github.com/aserto-dev/go-edge-ds v0.33.8/go.mod h1:f7mAjPSBUa9wXYUdk++JeXav9Z2T+/bwvMmdGz7pxCw=
 github.com/aserto-dev/go-grpc v0.9.4 h1:d5n1vOptiKw0wmIt6nhT0Us2ANjKBCYpSQ7+0r9Ll2s=
 github.com/aserto-dev/go-grpc v0.9.4/go.mod h1:R2bxW+34GuqclhWOnpTzEA9cIc9ay1U3WAOqS1a4TR8=
 github.com/aserto-dev/go-topaz-ui v0.1.17 h1:a/kalD0K+bQbejXF0CWf8p266XuiIFBIaS7xTwt6BlM=
@@ -458,6 +466,7 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -574,6 +583,8 @@ github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.10.4 h1:JSwxQzIqKfmFX1swYPpUThQZp/Ka4wzJdK0LWVytLPM=
 github.com/goccy/go-json v0.10.4/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -616,6 +627,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/cel-go v0.22.1 h1:AfVXx3chM2qwoSbM7Da8g8hX8OVSkBFwX+rz2+PcK40=
 github.com/google/cel-go v0.22.1/go.mod h1:BuznPXXfQDpXKWQ9sPW3TzlAJN5zzFe+i9tIs0yC4s8=
+github.com/google/cel-go v0.23.1 h1:91ThhEZlBcE5rB2adBVXqvDoqdL8BG2oyhd0bK1I/r4=
+github.com/google/cel-go v0.23.1/go.mod h1:52Pb6QsDbC5kvgxvZhiL9QX1oZEkcUF/ZqaPx1J5Wwo=
 github.com/google/flatbuffers v24.12.23+incompatible h1:ubBKR94NR4pXUCY/MUsRVzd9umNW7ht7EG9hHfS9FX8=
 github.com/google/flatbuffers v24.12.23+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -686,6 +699,7 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0 h1:kQ0NI7W1B3HwiN5gAYtY+X
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0/go.mod h1:zrT2dxOAjNFPRGjTUe2Xmb4q4YdUwVvQFV6xiCSf+z0=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.0 h1:VD1gqscl4nYs1YxVuSdemTrSgTKrwOWDK0FVFMqm+Cg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.0/go.mod h1:4EgsQoS4TOhJizV+JTFg40qx1Ofh3XmXEQNBpgvNT40=
@@ -764,6 +778,7 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -813,6 +828,7 @@ github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2sz
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/panmari/cuckoofilter v1.0.6 h1:WKb1aSj16h22x0CKVtTCaRkJiCnVGPLEMGbNY8xwXf8=
 github.com/panmari/cuckoofilter v1.0.6/go.mod h1:bKADbQPGbN6TxUvo/IbMEIUbKuASnpsOvrLTgpSX0aU=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -858,6 +874,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/samber/lo v1.49.0 h1:AGnTnQrg1jpFuwECPUSoxZCfVH5W22b605kWSry3YxM=
 github.com/samber/lo v1.49.0/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
+github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
+github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/iZ9pI=
@@ -991,6 +1009,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
 golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c h1:KL/ZBHXgKGVmuZBZ01Lt57yE5ws8ZPSkkihmEyq7FXc=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/app/tests/ds/checks_test.go
+++ b/pkg/app/tests/ds/checks_test.go
@@ -53,6 +53,7 @@ func testChecks(ctx context.Context, dsClient dsr3.ReaderClient) func(*testing.T
 }
 
 var checksTCs []*checksTestCase = []*checksTestCase{
+	// id = 0
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{
@@ -77,6 +78,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 1
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{
@@ -101,6 +103,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 2
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{
@@ -125,6 +128,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 3
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{
@@ -149,6 +153,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 4
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{
@@ -173,6 +178,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 5
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{
@@ -197,6 +203,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 6
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{},
@@ -221,6 +228,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 7
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{},
@@ -245,6 +253,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 8
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{},
@@ -269,6 +278,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 9
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{},
@@ -293,6 +303,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 10
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{},
@@ -317,6 +328,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 11
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{},
@@ -341,6 +353,7 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 		},
 		err: nil,
 	},
+	// id = 12
 	{
 		req: &dsr3.ChecksRequest{
 			Default: &dsr3.CheckRequest{
@@ -387,5 +400,128 @@ var checksTCs []*checksTestCase = []*checksTestCase{
 			},
 		},
 		err: nil,
+	},
+	// id = 13 - default checks request, no fields set.
+	{
+		req:  &dsr3.ChecksRequest{},
+		resp: &dsr3.ChecksResponse{},
+		err:  nil,
+	},
+	// id = 14 - default checks request, with empty "default" field.
+	{
+		req: &dsr3.ChecksRequest{
+			Default: &dsr3.CheckRequest{},
+		},
+		resp: &dsr3.ChecksResponse{},
+		err:  nil,
+	},
+	// id 15 - default checks request, with empty "checks" field.
+	{
+		req: &dsr3.ChecksRequest{
+			Checks: []*dsr3.CheckRequest{},
+		},
+		resp: &dsr3.ChecksResponse{
+			Checks: []*dsr3.CheckResponse{},
+		},
+		err: nil,
+	},
+	// id = 16 - default checks request, with empty "checks" field.
+	{
+		req: &dsr3.ChecksRequest{
+			Default: &dsr3.CheckRequest{},
+			Checks:  []*dsr3.CheckRequest{{}},
+		},
+		resp: &dsr3.ChecksResponse{
+			Checks: []*dsr3.CheckResponse{
+				{
+					Check:   false,
+					Context: tc.SetContext(prop.Reason, "E20025 object not found: E20046 invalid argument object identifier: type: type: object_type"),
+				},
+			},
+		},
+		err: nil,
+	},
+	// id = 17 - default sub-request is nil
+	{
+		req: &dsr3.ChecksRequest{
+			Checks: []*dsr3.CheckRequest{
+				{
+					ObjectType:  "folder",
+					ObjectId:    "morty",
+					Relation:    "owner",
+					SubjectType: "user",
+					SubjectId:   "morty@the-citadel.com",
+					Trace:       false,
+				},
+			},
+		},
+		resp: &dsr3.ChecksResponse{
+			Checks: []*dsr3.CheckResponse{
+				{
+					Check: true,
+				},
+			},
+		},
+		err: nil,
+	},
+	// id = 18 - checks array in nil
+	{
+		req: &dsr3.ChecksRequest{
+			Default: &dsr3.CheckRequest{
+				ObjectType:  "folder",
+				ObjectId:    "morty",
+				Relation:    "owner",
+				SubjectType: "user",
+				SubjectId:   "morty@the-citadel.com",
+				Trace:       false,
+			},
+		},
+		resp: &dsr3.ChecksResponse{
+			Checks: []*dsr3.CheckResponse{},
+		},
+		err: nil,
+	},
+	// id = 19 - checks array is empty
+	{
+		req: &dsr3.ChecksRequest{
+			Default: &dsr3.CheckRequest{
+				ObjectType:  "folder",
+				ObjectId:    "morty",
+				Relation:    "owner",
+				SubjectType: "user",
+				SubjectId:   "morty@the-citadel.com",
+				Trace:       false,
+			},
+			Checks: []*dsr3.CheckRequest{},
+		},
+		resp: &dsr3.ChecksResponse{},
+		err:  nil,
+	},
+	// id = 20 - default + checks == nil
+	{
+		req: &dsr3.ChecksRequest{
+			Default: nil,
+			Checks:  nil,
+		},
+		resp: &dsr3.ChecksResponse{},
+		err:  nil,
+	},
+	// id = 20 - default = empty, checks = nil
+	{
+		req: &dsr3.ChecksRequest{
+			Default: &dsr3.CheckRequest{},
+			Checks:  nil,
+		},
+		resp: &dsr3.ChecksResponse{},
+		err:  nil,
+	},
+	// id = 20 - default = nil;, checks = empty
+	{
+		req: &dsr3.ChecksRequest{
+			Default: nil,
+			Checks:  []*dsr3.CheckRequest{},
+		},
+		resp: &dsr3.ChecksResponse{},
+		err:  nil,
 	},
 }


### PR DESCRIPTION
* Update to go-edge-ds v0.33.8 (https://github.com/aserto-dev/go-edge-ds/pull/123)
* Add tests to `checks` test suite