### PR TITLE
upd identity resolution

### DIFF
--- a/assets/gdrive-inv/test/gdrive_decisions.json
+++ b/assets/gdrive-inv/test/gdrive_decisions.json
@@ -4,7 +4,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -28,7 +28,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -52,7 +52,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -76,7 +76,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -100,7 +100,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -124,7 +124,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -148,7 +148,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -172,7 +172,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -196,7 +196,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -220,7 +220,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -244,7 +244,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -268,7 +268,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -292,7 +292,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -316,7 +316,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -340,7 +340,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -364,7 +364,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -388,7 +388,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -412,7 +412,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -436,7 +436,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -460,7 +460,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -484,7 +484,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -508,7 +508,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -532,7 +532,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -556,7 +556,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -580,7 +580,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -604,7 +604,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -628,7 +628,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -652,7 +652,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -676,7 +676,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -700,7 +700,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -724,7 +724,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -748,7 +748,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -772,7 +772,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -796,7 +796,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -820,7 +820,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -844,7 +844,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -868,7 +868,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -892,7 +892,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -916,7 +916,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -940,7 +940,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -964,7 +964,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -988,7 +988,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1012,7 +1012,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1036,7 +1036,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1060,7 +1060,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1084,7 +1084,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1108,7 +1108,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1132,7 +1132,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1156,7 +1156,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1180,7 +1180,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1204,7 +1204,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1228,7 +1228,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1252,7 +1252,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1276,7 +1276,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1300,7 +1300,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1324,7 +1324,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1348,7 +1348,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1372,7 +1372,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1396,7 +1396,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1420,7 +1420,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1444,7 +1444,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1468,7 +1468,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1492,7 +1492,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1516,7 +1516,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1540,7 +1540,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1564,7 +1564,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1588,7 +1588,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1612,7 +1612,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1636,7 +1636,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1660,7 +1660,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1684,7 +1684,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1708,7 +1708,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1732,7 +1732,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1756,7 +1756,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1780,7 +1780,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1804,7 +1804,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1828,7 +1828,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1852,7 +1852,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1876,7 +1876,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1900,7 +1900,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1924,7 +1924,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1948,7 +1948,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1972,7 +1972,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -1996,7 +1996,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2020,7 +2020,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2044,7 +2044,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2068,7 +2068,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2092,7 +2092,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2116,7 +2116,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2140,7 +2140,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2164,7 +2164,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2188,7 +2188,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2212,7 +2212,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2236,7 +2236,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2260,7 +2260,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2284,7 +2284,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2308,7 +2308,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2332,7 +2332,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2356,7 +2356,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2380,7 +2380,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2404,7 +2404,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2428,7 +2428,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2452,7 +2452,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2476,7 +2476,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2500,7 +2500,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2524,7 +2524,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2548,7 +2548,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2572,7 +2572,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2596,7 +2596,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2620,7 +2620,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2644,7 +2644,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2668,7 +2668,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2692,7 +2692,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2716,7 +2716,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2740,7 +2740,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2764,7 +2764,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2788,7 +2788,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2812,7 +2812,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2836,7 +2836,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2860,7 +2860,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2884,7 +2884,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2908,7 +2908,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2932,7 +2932,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2956,7 +2956,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -2980,7 +2980,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3004,7 +3004,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3028,7 +3028,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3052,7 +3052,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3076,7 +3076,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3100,7 +3100,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3124,7 +3124,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3148,7 +3148,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3172,7 +3172,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3196,7 +3196,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3220,7 +3220,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3244,7 +3244,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3268,7 +3268,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3292,7 +3292,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3316,7 +3316,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3340,7 +3340,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3364,7 +3364,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3388,7 +3388,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3412,7 +3412,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3436,7 +3436,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3460,7 +3460,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3484,7 +3484,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3508,7 +3508,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3532,7 +3532,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3556,7 +3556,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3580,7 +3580,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3604,7 +3604,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3628,7 +3628,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3652,7 +3652,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3676,7 +3676,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3700,7 +3700,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3724,7 +3724,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3748,7 +3748,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3772,7 +3772,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3796,7 +3796,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3820,7 +3820,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3844,7 +3844,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3868,7 +3868,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3892,7 +3892,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3916,7 +3916,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3940,7 +3940,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3964,7 +3964,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -3988,7 +3988,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4012,7 +4012,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4036,7 +4036,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "beth@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4060,7 +4060,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4084,7 +4084,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4108,7 +4108,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4132,7 +4132,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4156,7 +4156,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "rick@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4180,7 +4180,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4204,7 +4204,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4228,7 +4228,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4252,7 +4252,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4276,7 +4276,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "morty@the-citadel.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4300,7 +4300,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4324,7 +4324,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4348,7 +4348,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4372,7 +4372,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "summer@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4396,7 +4396,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4420,7 +4420,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4444,7 +4444,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [
@@ -4468,7 +4468,7 @@
       "check_decision": {
         "identity_context": {
           "identity": "jerry@the-smiths.com",
-          "type": "IDENTITY_TYPE_MANUAL"
+          "type": "IDENTITY_TYPE_SUB"
         },
         "policy_context": {
           "decisions": [

--- a/builtins/edge/ds/identity.go
+++ b/builtins/edge/ds/identity.go
@@ -41,7 +41,7 @@ func RegisterIdentity(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 				return help(fnName, argsV3{})
 			}
 
-			user, err := directory.GetIdentityV2(bctx.Context, dr.GetDS(), args.ID)
+			user, err := directory.ResolveIdentity(bctx.Context, dr.GetDS(), args.ID)
 			switch {
 			case status.Code(err) == codes.NotFound:
 				traceError(&bctx, fnName, err)

--- a/builtins/edge/ds/object.go
+++ b/builtins/edge/ds/object.go
@@ -21,19 +21,10 @@ import (
 
 // RegisterObject - ds.object
 //
-// v3 (latest) request format:
-//
 //	ds.object({
 //		"object_type": "",
 //		"object_id": "",
 //		"with_relation": false
-//	})
-//
-// v2 request format:
-//
-//	ds.object({
-//		"type": "",
-//		"key": ""
 //	})
 func RegisterObject(logger *zerolog.Logger, fnName string, dr resolvers.DirectoryResolver) (*rego.Function, rego.Builtin1) {
 	return &rego.Function{

--- a/builtins/edge/ds/relation.go
+++ b/builtins/edge/ds/relation.go
@@ -88,20 +88,18 @@ func RegisterRelation(logger *zerolog.Logger, fnName string, dr resolvers.Direct
 		}
 }
 
-// TODO : update v3 format
+// RegisterRelations - ds.relations
 //
-//	RegisterRelations - ds.relations({
-//		"ds.relations": {
-//			"object_type": "",
-//			"object_id": "",
-//			"relation": "",
-//			"subject_type": "",
-//			"subject_id": "",
-//			"subject_relation": "",
-//			"with_objects": false,
-//			"with_empty_subject_relation": false
-//		}
-//	})
+//	ds.relations: {
+//		object_type: "",
+//		object_id: "",
+//		relation: "",
+//		subject_type: "",
+//		subject_id: "",
+//		subject_relation: "",
+//		with_objects: false,
+//		with_empty_subject_relation: false
+//	}
 func RegisterRelations(logger *zerolog.Logger, fnName string, dr resolvers.DirectoryResolver) (*rego.Function, rego.Builtin1) {
 	return &rego.Function{
 			Name:    fnName,

--- a/directory/identity.go
+++ b/directory/identity.go
@@ -2,40 +2,71 @@ package directory
 
 import (
 	"context"
-	"errors"
 	"strings"
 
-	cerr "github.com/aserto-dev/errors"
 	"github.com/aserto-dev/go-authorizer/pkg/aerr"
 	dsc3 "github.com/aserto-dev/go-directory/aserto/directory/common/v3"
 	dsr3 "github.com/aserto-dev/go-directory/aserto/directory/reader/v3"
-	"github.com/aserto-dev/go-directory/pkg/derr"
+	"github.com/samber/lo"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-func GetIdentityV2(ctx context.Context, client dsr3.ReaderClient, identity string) (*dsc3.Object, error) {
-	relResp, err := client.GetRelation(ctx, &dsr3.GetRelationRequest{
-		ObjectType:  "identity",
-		ObjectId:    identity,
-		Relation:    "identifier",
-		SubjectType: "user",
-		WithObjects: true,
-	})
+const (
+	User       string = "user"
+	Identifier string = "identifier"
+	Identity   string = "identity"
+)
 
+func ResolveIdentity(ctx context.Context, client dsr3.ReaderClient, identity string) (*dsc3.Object, error) {
+	if obj, err := resolveIdentity(ctx, client, identity); err == nil {
+		return obj, nil
+	}
+	return resolveIdentityLegacy(ctx, client, identity)
+}
+
+// resolveIdentity, resolves object_type:user->subject_type:identity (inverted identity)
+func resolveIdentity(ctx context.Context, client dsr3.ReaderClient, identity string) (*dsc3.Object, error) {
+	relReq := &dsr3.GetRelationRequest{
+		ObjectType:  User,
+		Relation:    Identifier,
+		SubjectType: Identity,
+		SubjectId:   identity,
+		WithObjects: true,
+	}
+	return resolveIdentityToUser(ctx, client, relReq)
+}
+
+// resolveIdentityLegacy, resolves object_type:identity->subject_type:user (legacy)
+func resolveIdentityLegacy(ctx context.Context, client dsr3.ReaderClient, identity string) (*dsc3.Object, error) {
+	relReq := &dsr3.GetRelationRequest{
+		ObjectType:  Identity,
+		ObjectId:    identity,
+		Relation:    Identifier,
+		SubjectType: User,
+		WithObjects: true,
+	}
+	return resolveIdentityToUser(ctx, client, relReq)
+}
+
+func resolveIdentityToUser(ctx context.Context, client dsr3.ReaderClient, relReq *dsr3.GetRelationRequest) (*dsc3.Object, error) {
+	relResp, err := client.GetRelation(ctx, relReq)
 	switch {
-	case err != nil && errors.Is(cerr.UnwrapAsertoError(err), derr.ErrNotFound):
+	case err != nil && status.Code(err) == codes.NotFound:
 		return nil, aerr.ErrDirectoryObjectNotFound
 	case err != nil:
 		return nil, err
-
 	case relResp.Result == nil:
 		return nil, aerr.ErrDirectoryObjectNotFound
-
 	case len(relResp.Objects) == 0:
-		return nil, aerr.ErrDirectoryObjectNotFound.Msg("no objects found in relation")
+		return &dsc3.Object{
+			Type: User,
+			Id:   lo.Ternary(relResp.Result.ObjectType == User, relResp.Result.ObjectId, relResp.Result.SubjectId),
+		}, nil
 	}
 
 	for k, v := range relResp.Objects {
-		if strings.HasPrefix(k, "user:") {
+		if strings.HasPrefix(k, User+":") {
 			return v, nil
 		}
 	}

--- a/directory/identity.go
+++ b/directory/identity.go
@@ -25,7 +25,7 @@ func ResolveIdentity(ctx context.Context, client dsr3.ReaderClient, identity str
 	return resolveIdentityLegacy(ctx, client, identity)
 }
 
-// resolveIdentity, resolves object_type:user->subject_type:identity (inverted identity)
+// resolveIdentity, resolves object_type:user->subject_type:identity (inverted identity).
 func resolveIdentity(ctx context.Context, client dsr3.ReaderClient, identity string) (*dsc3.Object, error) {
 	relReq := &dsr3.GetRelationRequest{
 		ObjectType:  User,
@@ -37,7 +37,7 @@ func resolveIdentity(ctx context.Context, client dsr3.ReaderClient, identity str
 	return resolveIdentityToUser(ctx, client, relReq)
 }
 
-// resolveIdentityLegacy, resolves object_type:identity->subject_type:user (legacy)
+// resolveIdentityLegacy, resolves object_type:identity->subject_type:user (legacy).
 func resolveIdentityLegacy(ctx context.Context, client dsr3.ReaderClient, identity string) (*dsc3.Object, error) {
 	relReq := &dsr3.GetRelationRequest{
 		ObjectType:  Identity,

--- a/pkg/app/impl/jwt.go
+++ b/pkg/app/impl/jwt.go
@@ -233,8 +233,7 @@ func (s *AuthorizerServer) getUserFromIdentity(ctx context.Context, identity str
 	user, err := directory.ResolveIdentity(ctx, client, identity)
 	switch {
 	case status.Code(err) == codes.NotFound:
-		// Try to find a user with key == identity
-		return s.getObject(ctx, "user", identity)
+		return s.getUserObject(ctx, identity)
 	case err != nil:
 		return nil, err
 	default:
@@ -242,11 +241,12 @@ func (s *AuthorizerServer) getUserFromIdentity(ctx context.Context, identity str
 	}
 }
 
-func (s *AuthorizerServer) getObject(ctx context.Context, objType, objID string) (proto.Message, error) {
+// getUserObject, retrieves an user object, using the identity as the object_id (legacy).
+func (s *AuthorizerServer) getUserObject(ctx context.Context, objID string) (proto.Message, error) {
 	client := s.resolver.GetDirectoryResolver().GetDS()
 
 	objResp, err := client.GetObject(ctx, &dsr3.GetObjectRequest{
-		ObjectType: objType,
+		ObjectType: "user",
 		ObjectId:   objID,
 	})
 	if err != nil {

--- a/pkg/app/impl/jwt.go
+++ b/pkg/app/impl/jwt.go
@@ -246,7 +246,7 @@ func (s *AuthorizerServer) getUserObject(ctx context.Context, objID string) (pro
 	client := s.resolver.GetDirectoryResolver().GetDS()
 
 	objResp, err := client.GetObject(ctx, &dsr3.GetObjectRequest{
-		ObjectType: "user",
+		ObjectType: directory.User,
 		ObjectId:   objID,
 	})
 	if err != nil {


### PR DESCRIPTION
Update identity resolution to handle inverted identities, where identity instances are the `subject_type` of the relation, instead of the `user`

In the case of inverted identities, the `identity` is the `subject_type` of the `identifier` `relation`.
* resolves: `object_type`:`user`->`subject_type`:`identity` 

In the legacy case, the `identity` is the `object_type` of the `identifier` `relation`. 
* resolves: `object_type:identity->subject_type:user`
