### PR TITLE
`topaz start` deletes container if it can't be started.

### DIFF
--- a/pkg/cli/dockerx/docker.go
+++ b/pkg/cli/dockerx/docker.go
@@ -430,6 +430,9 @@ func (dc *DockerClient) Start(opts ...RunOption) error {
 	}
 
 	if err := dc.cli.ContainerStart(dc.ctx, cont.ID, container.StartOptions{}); err != nil {
+		// The container can't be started (most likely port already in use, bad image, or bad volume configuration).
+		// Remove the container to free up the name.
+		_ = dc.cli.ContainerRemove(dc.ctx, cont.ID, container.RemoveOptions{})
 		return err
 	}
 


### PR DESCRIPTION
The call to `ContainerStart` can fail for various reasons including:
* missing or invalid image
* port already in use
* bad volume configuration

All these failures represent a problem at the docker level, not in `topazd` or its configuration. It's not that the process started and exited with an error. It never ran at all.

In those cases we should delete the container in order to free up the name. Otherewise users need to explicitly `docker rm` the container before trying again.