### PR TITLE
Hold controller server config by value

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -5,6 +5,6 @@ import (
 )
 
 type Config struct {
-	Enabled bool           `json:"enabled"`
-	Server  *client.Config `json:"server"`
+	Enabled bool          `json:"enabled"`
+	Server  client.Config `json:"server"`
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -37,14 +37,7 @@ func NewController(logger *zerolog.Logger, policyName, host string, cfg *Config,
 	if !cfg.Enabled {
 		return nil, nil
 	}
-	if cfg.Server == nil {
-		return nil, errors.New("no server configuration provided")
-	}
-	conn, err := cfg.Server.Connect()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize new connection")
-	}
-	remoteCli := management.NewControllerClient(conn)
+
 	newLogger := logger.With().Fields(map[string]interface{}{
 		"component":   "controller",
 		"tenant-id":   cfg.Server.TenantID,
@@ -52,8 +45,13 @@ func NewController(logger *zerolog.Logger, policyName, host string, cfg *Config,
 		"host":        host,
 	}).Logger()
 
+	conn, err := cfg.Server.Connect()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize new connection")
+	}
+
 	return &Controller{
-		client: remoteCli,
+		client: management.NewControllerClient(conn),
 		instanceInfo: &api.InstanceInfo{
 			PolicyName:  policyName,
 			PolicyLabel: policyName,

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -34,7 +34,7 @@ func TestEnabledController(t *testing.T) {
 	logger := zerolog.Nop()
 	ctrl, err := controller.NewController(&logger, "test", "test-host", &controller.Config{
 		Enabled: true,
-		Server: &client.Config{
+		Server: client.Config{
 			Address: "localhost:1234",
 		},
 	}, func(ctx context.Context, c *api.Command) error { return nil })
@@ -47,7 +47,7 @@ func TestControllerLogMessages(t *testing.T) {
 	logger := zerolog.New(zerolog.ConsoleWriter{Out: buf, NoColor: true})
 	ctrl, err := controller.NewController(&logger, "test", "test-host", &controller.Config{
 		Enabled: true,
-		Server: &client.Config{
+		Server: client.Config{
 			Address: "localhost:1234",
 		},
 	}, func(ctx context.Context, c *api.Command) error { return nil })

--- a/pkg/app/topaz.go
+++ b/pkg/app/topaz.go
@@ -218,14 +218,14 @@ func (e *Topaz) ConfigServices() error {
 
 func (e *Topaz) setupHealthAndMetrics() ([]grpc.ServerOption, error) {
 	if e.Configuration.APIConfig.Health.ListenAddress != "" {
-		err := e.Manager.SetupHealthServer(e.Configuration.APIConfig.Health.ListenAddress, e.Configuration.APIConfig.Health.Certificates)
+		err := e.Manager.SetupHealthServer(e.Configuration.APIConfig.Health.ListenAddress, &e.Configuration.APIConfig.Health.Certificates)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if e.Configuration.APIConfig.Metrics.ListenAddress != "" {
 		metricsMiddleware, err := e.Manager.SetupMetricsServer(e.Configuration.APIConfig.Metrics.ListenAddress,
-			e.Configuration.APIConfig.Metrics.Certificates,
+			&e.Configuration.APIConfig.Metrics.Certificates,
 			false)
 		if err != nil {
 			return nil, err

--- a/pkg/app/topaz/runtime_resolver.go
+++ b/pkg/app/topaz/runtime_resolver.go
@@ -82,7 +82,7 @@ func NewRuntimeResolver(
 		if len(details) < 1 {
 			return nil, func() {}, aerr.ErrBadRuntime.Msg("provided discovery resource not formatted correctly")
 		}
-		ctrl, err := controller.NewController(logger, details[0], host, cfg.ControllerConfig, func(cmdCtx context.Context, cmd *api.Command) error {
+		ctrl, err := controller.NewController(logger, details[0], host, &cfg.ControllerConfig, func(cmdCtx context.Context, cmd *api.Command) error {
 			return management.HandleCommand(cmdCtx, cmd, sidecarRuntime)
 		})
 		if err != nil {

--- a/pkg/cc/config/config.go
+++ b/pkg/cc/config/config.go
@@ -30,13 +30,13 @@ const (
 
 type ServicesConfig struct {
 	Health struct {
-		ListenAddress string            `json:"listen_address"`
-		Certificates  *client.TLSConfig `json:"certs"`
+		ListenAddress string           `json:"listen_address"`
+		Certificates  client.TLSConfig `json:"certs"`
 	} `json:"health"`
 	Metrics struct {
-		ListenAddress string            `json:"listen_address"`
-		Certificates  *client.TLSConfig `json:"certs"`
-		ZPages        bool              `json:"zpages"`
+		ListenAddress string           `json:"listen_address"`
+		Certificates  client.TLSConfig `json:"certs"`
+		ZPages        bool             `json:"zpages"`
 	} `json:"metrics"`
 	Services map[string]*builder.API `json:"services"`
 }

--- a/pkg/cc/config/loader.go
+++ b/pkg/cc/config/loader.go
@@ -97,28 +97,25 @@ func (l *Loader) GetPaths() ([]string, error) {
 	if l.Configuration.Edge.DBPath != "" {
 		paths[l.Configuration.Edge.DBPath] = true
 	}
-	if l.Configuration.APIConfig.Health.Certificates != nil {
-		if l.Configuration.APIConfig.Health.Certificates.CA != "" {
-			paths[l.Configuration.APIConfig.Health.Certificates.CA] = true
-		}
-		if l.Configuration.APIConfig.Health.Certificates.Cert != "" {
-			paths[l.Configuration.APIConfig.Health.Certificates.Cert] = true
-		}
-		if l.Configuration.APIConfig.Health.Certificates.Key != "" {
-			paths[l.Configuration.APIConfig.Health.Certificates.Key] = true
-		}
+
+	if l.Configuration.APIConfig.Health.Certificates.CA != "" {
+		paths[l.Configuration.APIConfig.Health.Certificates.CA] = true
+	}
+	if l.Configuration.APIConfig.Health.Certificates.Cert != "" {
+		paths[l.Configuration.APIConfig.Health.Certificates.Cert] = true
+	}
+	if l.Configuration.APIConfig.Health.Certificates.Key != "" {
+		paths[l.Configuration.APIConfig.Health.Certificates.Key] = true
 	}
 
-	if l.Configuration.APIConfig.Metrics.Certificates != nil {
-		if l.Configuration.APIConfig.Metrics.Certificates.CA != "" {
-			paths[l.Configuration.APIConfig.Metrics.Certificates.CA] = true
-		}
-		if l.Configuration.APIConfig.Metrics.Certificates.Cert != "" {
-			paths[l.Configuration.APIConfig.Metrics.Certificates.Cert] = true
-		}
-		if l.Configuration.APIConfig.Metrics.Certificates.Key != "" {
-			paths[l.Configuration.APIConfig.Metrics.Certificates.Key] = true
-		}
+	if l.Configuration.APIConfig.Metrics.Certificates.CA != "" {
+		paths[l.Configuration.APIConfig.Metrics.Certificates.CA] = true
+	}
+	if l.Configuration.APIConfig.Metrics.Certificates.Cert != "" {
+		paths[l.Configuration.APIConfig.Metrics.Certificates.Cert] = true
+	}
+	if l.Configuration.APIConfig.Metrics.Certificates.Key != "" {
+		paths[l.Configuration.APIConfig.Metrics.Certificates.Key] = true
 	}
 
 	servicePaths := getUniqueServiceCertPaths(l.Configuration.APIConfig.Services)
@@ -126,7 +123,7 @@ func (l *Loader) GetPaths() ([]string, error) {
 		paths[servicePaths[i]] = true
 	}
 
-	if l.Configuration.ControllerConfig != nil && l.Configuration.ControllerConfig.Enabled {
+	if l.Configuration.ControllerConfig.Enabled {
 		if l.Configuration.ControllerConfig.Server.CACertPath != "" {
 			paths[l.Configuration.ControllerConfig.Server.CACertPath] = true
 		}

--- a/pkg/cc/config/topaz_config.go
+++ b/pkg/cc/config/topaz_config.go
@@ -12,10 +12,10 @@ import (
 const ConfigFileVersion = 2
 
 type Config struct {
-	Common           `json:",squash"`   // nolint:staticcheck // squash is used by mapstructure
-	Auth             AuthnConfig        `json:"auth"`
-	DecisionLogger   DecisionLogConfig  `json:"decision_logger"`
-	ControllerConfig *controller.Config `json:"controller"`
+	Common           `json:",squash"`  // nolint:staticcheck // squash is used by mapstructure
+	Auth             AuthnConfig       `json:"auth"`
+	DecisionLogger   DecisionLogConfig `json:"decision_logger"`
+	ControllerConfig controller.Config `json:"controller"`
 }
 
 type DecisionLogConfig struct {


### PR DESCRIPTION
Holding config values by reference is risky because callers may be tempted to make copies in order to override fields and don't expect those copies to be shallow.