### PR TITLE
add access service commands to topaz CLI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -119,6 +119,7 @@ issues:
     - path: _test\.go
       linters:
       - gomnd
+      - funlen
     # https://github.com/go-critic/go-critic/issues/926
     - text: "unnecessaryDefer:"
       linters:

--- a/makefile
+++ b/makefile
@@ -41,7 +41,6 @@ gover:
 .PHONY: build
 build: gover
 	@echo -e "$(ATTN_COLOR)==> $@ $(NO_COLOR)"
-	@(go env GOVERSION | grep "go${GO_VER}") || (echo "go version check failed expected go${GO_VER} got $$(go env GOVERSION)"; exit 1)
 	@${EXT_BIN_DIR}/goreleaser build --clean --snapshot --single-target
 
 PHONY: go-mod-tidy

--- a/pkg/cli/cmd/access/access.go
+++ b/pkg/cli/cmd/access/access.go
@@ -1,0 +1,9 @@
+package access
+
+type AccessCmd struct {
+	Evaluation     EvaluationCmd     `cmd:"" help:""`
+	Evaluations    EvaluationsCmd    `cmd:"" help:""`
+	SubjectSearch  SubjectSearchCmd  `cmd:"" help:""`
+	ResourceSearch ResourceSearchCmd `cmd:"" help:""`
+	ActionSearch   ActionSearchCmd   `cmd:"" help:""`
+}

--- a/pkg/cli/cmd/access/actionsearch.go
+++ b/pkg/cli/cmd/access/actionsearch.go
@@ -1,0 +1,90 @@
+package access
+
+import (
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+	"github.com/aserto-dev/topaz/pkg/cli/edit"
+	"github.com/aserto-dev/topaz/pkg/cli/fflag"
+	"github.com/aserto-dev/topaz/pkg/cli/jsonx"
+	"github.com/aserto-dev/topaz/pkg/cli/pb"
+	"github.com/aserto-dev/topaz/pkg/cli/prompter"
+	dsa1 "github.com/authzen/access.go/api/access/v1"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type ActionSearchCmd struct {
+	Request  string `arg:"" type:"string" name:"request" optional:"" help:"json request or file path to get relation request or '-' to read from stdin"`
+	Template bool   `name:"template" short:"t" help:"prints a get relation request template on stdout"`
+	Editor   bool   `name:"edit" short:"e" help:"edit request" hidden:"" type:"fflag.Editor"`
+	dsc.Config
+}
+
+func (cmd *ActionSearchCmd) Run(c *cc.CommonCtx) error {
+	if cmd.Template {
+		return jsonx.OutputJSONPB(c.StdOut(), cmd.template())
+	}
+
+	client, err := dsc.NewClient(c, &cmd.Config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get directory client")
+	}
+
+	if cmd.Request == "" && cmd.Editor && fflag.Enabled(fflag.Editor) {
+		req, err := edit.Msg(cmd.template())
+		if err != nil {
+			return err
+		}
+		cmd.Request = req
+	}
+
+	if cmd.Request == "" && fflag.Enabled(fflag.Prompter) {
+		p := prompter.New(cmd.template())
+		if err := p.Show(); err != nil {
+			return err
+		}
+		cmd.Request = jsonx.MaskedMarshalOpts().Format(p.Req())
+	}
+
+	if cmd.Request == "" {
+		return errors.New("request argument is required")
+	}
+
+	var req dsa1.ActionSearchRequest
+	err = pb.UnmarshalRequest(cmd.Request, &req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Access.ActionSearch(c.Context, &req)
+	if err != nil {
+		return errors.Wrap(err, "action search call failed")
+	}
+
+	return jsonx.OutputJSONPB(c.StdOut(), resp)
+}
+
+func (cmd *ActionSearchCmd) template() proto.Message {
+	return &dsa1.ActionSearchRequest{
+		Subject: &dsa1.Subject{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Action: &dsa1.Action{
+			Name:       "",
+			Properties: &structpb.Struct{},
+		},
+		Resource: &dsa1.Resource{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Context: &structpb.Struct{},
+		Page: &dsa1.Page{
+			NextToken: "",
+		},
+	}
+}

--- a/pkg/cli/cmd/access/evaluation.go
+++ b/pkg/cli/cmd/access/evaluation.go
@@ -1,0 +1,87 @@
+package access
+
+import (
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+	"github.com/aserto-dev/topaz/pkg/cli/edit"
+	"github.com/aserto-dev/topaz/pkg/cli/fflag"
+	"github.com/aserto-dev/topaz/pkg/cli/jsonx"
+	"github.com/aserto-dev/topaz/pkg/cli/pb"
+	"github.com/aserto-dev/topaz/pkg/cli/prompter"
+	dsa1 "github.com/authzen/access.go/api/access/v1"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type EvaluationCmd struct {
+	Request  string `arg:"" type:"string" name:"request" optional:"" help:"json request or file path to get relation request or '-' to read from stdin"`
+	Template bool   `name:"template" short:"t" help:"prints a get relation request template on stdout"`
+	Editor   bool   `name:"edit" short:"e" help:"edit request" hidden:"" type:"fflag.Editor"`
+	dsc.Config
+}
+
+func (cmd *EvaluationCmd) Run(c *cc.CommonCtx) error {
+	if cmd.Template {
+		return jsonx.OutputJSONPB(c.StdOut(), cmd.template())
+	}
+
+	client, err := dsc.NewClient(c, &cmd.Config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get directory client")
+	}
+
+	if cmd.Request == "" && cmd.Editor && fflag.Enabled(fflag.Editor) {
+		req, err := edit.Msg(cmd.template())
+		if err != nil {
+			return err
+		}
+		cmd.Request = req
+	}
+
+	if cmd.Request == "" && fflag.Enabled(fflag.Prompter) {
+		p := prompter.New(cmd.template())
+		if err := p.Show(); err != nil {
+			return err
+		}
+		cmd.Request = jsonx.MaskedMarshalOpts().Format(p.Req())
+	}
+
+	if cmd.Request == "" {
+		return errors.New("request argument is required")
+	}
+
+	var req dsa1.EvaluationRequest
+	err = pb.UnmarshalRequest(cmd.Request, &req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Access.Evaluation(c.Context, &req)
+	if err != nil {
+		return errors.Wrap(err, "evaluation call failed")
+	}
+
+	return jsonx.OutputJSONPB(c.StdOut(), resp)
+}
+
+func (cmd *EvaluationCmd) template() proto.Message {
+	return &dsa1.EvaluationRequest{
+		Subject: &dsa1.Subject{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Action: &dsa1.Action{
+			Name:       "",
+			Properties: &structpb.Struct{},
+		},
+		Resource: &dsa1.Resource{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Context: &structpb.Struct{},
+	}
+}

--- a/pkg/cli/cmd/access/evaluations.go
+++ b/pkg/cli/cmd/access/evaluations.go
@@ -1,0 +1,86 @@
+package access
+
+import (
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+	"github.com/aserto-dev/topaz/pkg/cli/edit"
+	"github.com/aserto-dev/topaz/pkg/cli/fflag"
+	"github.com/aserto-dev/topaz/pkg/cli/jsonx"
+	"github.com/aserto-dev/topaz/pkg/cli/pb"
+	dsa1 "github.com/authzen/access.go/api/access/v1"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type EvaluationsCmd struct {
+	Request  string `arg:"" type:"string" name:"request" optional:"" help:"json request or file path to get relation request or '-' to read from stdin"`
+	Template bool   `name:"template" short:"t" help:"prints a get relation request template on stdout"`
+	Editor   bool   `name:"edit" short:"e" help:"edit request" hidden:"" type:"fflag.Editor"`
+	dsc.Config
+}
+
+func (cmd *EvaluationsCmd) Run(c *cc.CommonCtx) error {
+	if cmd.Template {
+		return jsonx.OutputJSONPB(c.StdOut(), cmd.template())
+	}
+
+	client, err := dsc.NewClient(c, &cmd.Config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get directory client")
+	}
+
+	if cmd.Request == "" && cmd.Editor && fflag.Enabled(fflag.Editor) {
+		req, err := edit.Msg(cmd.template())
+		if err != nil {
+			return err
+		}
+		cmd.Request = req
+	}
+
+	if cmd.Request == "" && fflag.Enabled(fflag.Prompter) {
+		return status.Error(codes.Unavailable, "prompter is unavailable for access evaluations command")
+	}
+
+	if cmd.Request == "" {
+		return errors.New("request argument is required")
+	}
+
+	var req dsa1.EvaluationRequest
+	err = pb.UnmarshalRequest(cmd.Request, &req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Access.Evaluation(c.Context, &req)
+	if err != nil {
+		return errors.Wrap(err, "evaluations call failed")
+	}
+
+	return jsonx.OutputJSONPB(c.StdOut(), resp)
+}
+
+func (cmd *EvaluationsCmd) template() proto.Message {
+	return &dsa1.EvaluationsRequest{
+		Subject: &dsa1.Subject{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Action: &dsa1.Action{
+			Name:       "",
+			Properties: &structpb.Struct{},
+		},
+		Resource: &dsa1.Resource{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Context:     &structpb.Struct{},
+		Evaluations: []*dsa1.EvaluationRequest{},
+		Options:     &structpb.Struct{},
+	}
+}

--- a/pkg/cli/cmd/access/resourcesearch.go
+++ b/pkg/cli/cmd/access/resourcesearch.go
@@ -1,0 +1,90 @@
+package access
+
+import (
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+	"github.com/aserto-dev/topaz/pkg/cli/edit"
+	"github.com/aserto-dev/topaz/pkg/cli/fflag"
+	"github.com/aserto-dev/topaz/pkg/cli/jsonx"
+	"github.com/aserto-dev/topaz/pkg/cli/pb"
+	"github.com/aserto-dev/topaz/pkg/cli/prompter"
+	dsa1 "github.com/authzen/access.go/api/access/v1"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type ResourceSearchCmd struct {
+	Request  string `arg:"" type:"string" name:"request" optional:"" help:"json request or file path to get relation request or '-' to read from stdin"`
+	Template bool   `name:"template" short:"t" help:"prints a get relation request template on stdout"`
+	Editor   bool   `name:"edit" short:"e" help:"edit request" hidden:"" type:"fflag.Editor"`
+	dsc.Config
+}
+
+func (cmd *ResourceSearchCmd) Run(c *cc.CommonCtx) error {
+	if cmd.Template {
+		return jsonx.OutputJSONPB(c.StdOut(), cmd.template())
+	}
+
+	client, err := dsc.NewClient(c, &cmd.Config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get directory client")
+	}
+
+	if cmd.Request == "" && cmd.Editor && fflag.Enabled(fflag.Editor) {
+		req, err := edit.Msg(cmd.template())
+		if err != nil {
+			return err
+		}
+		cmd.Request = req
+	}
+
+	if cmd.Request == "" && fflag.Enabled(fflag.Prompter) {
+		p := prompter.New(cmd.template())
+		if err := p.Show(); err != nil {
+			return err
+		}
+		cmd.Request = jsonx.MaskedMarshalOpts().Format(p.Req())
+	}
+
+	if cmd.Request == "" {
+		return errors.New("request argument is required")
+	}
+
+	var req dsa1.ResourceSearchRequest
+	err = pb.UnmarshalRequest(cmd.Request, &req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Access.ResourceSearch(c.Context, &req)
+	if err != nil {
+		return errors.Wrap(err, "resource search call failed")
+	}
+
+	return jsonx.OutputJSONPB(c.StdOut(), resp)
+}
+
+func (cmd *ResourceSearchCmd) template() proto.Message {
+	return &dsa1.ResourceSearchRequest{
+		Subject: &dsa1.Subject{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Action: &dsa1.Action{
+			Name:       "",
+			Properties: &structpb.Struct{},
+		},
+		Resource: &dsa1.Resource{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Context: &structpb.Struct{},
+		Page: &dsa1.Page{
+			NextToken: "",
+		},
+	}
+}

--- a/pkg/cli/cmd/access/subjectsearch.go
+++ b/pkg/cli/cmd/access/subjectsearch.go
@@ -1,0 +1,90 @@
+package access
+
+import (
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+	"github.com/aserto-dev/topaz/pkg/cli/edit"
+	"github.com/aserto-dev/topaz/pkg/cli/fflag"
+	"github.com/aserto-dev/topaz/pkg/cli/jsonx"
+	"github.com/aserto-dev/topaz/pkg/cli/pb"
+	"github.com/aserto-dev/topaz/pkg/cli/prompter"
+	dsa1 "github.com/authzen/access.go/api/access/v1"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type SubjectSearchCmd struct {
+	Request  string `arg:"" type:"string" name:"request" optional:"" help:"json request or file path to get relation request or '-' to read from stdin"`
+	Template bool   `name:"template" short:"t" help:"prints a get relation request template on stdout"`
+	Editor   bool   `name:"edit" short:"e" help:"edit request" hidden:"" type:"fflag.Editor"`
+	dsc.Config
+}
+
+func (cmd *SubjectSearchCmd) Run(c *cc.CommonCtx) error {
+	if cmd.Template {
+		return jsonx.OutputJSONPB(c.StdOut(), cmd.template())
+	}
+
+	client, err := dsc.NewClient(c, &cmd.Config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get directory client")
+	}
+
+	if cmd.Request == "" && cmd.Editor && fflag.Enabled(fflag.Editor) {
+		req, err := edit.Msg(cmd.template())
+		if err != nil {
+			return err
+		}
+		cmd.Request = req
+	}
+
+	if cmd.Request == "" && fflag.Enabled(fflag.Prompter) {
+		p := prompter.New(cmd.template())
+		if err := p.Show(); err != nil {
+			return err
+		}
+		cmd.Request = jsonx.MaskedMarshalOpts().Format(p.Req())
+	}
+
+	if cmd.Request == "" {
+		return errors.New("request argument is required")
+	}
+
+	var req dsa1.SubjectSearchRequest
+	err = pb.UnmarshalRequest(cmd.Request, &req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Access.SubjectSearch(c.Context, &req)
+	if err != nil {
+		return errors.Wrap(err, "subject search call failed")
+	}
+
+	return jsonx.OutputJSONPB(c.StdOut(), resp)
+}
+
+func (cmd *SubjectSearchCmd) template() proto.Message {
+	return &dsa1.SubjectSearchRequest{
+		Subject: &dsa1.Subject{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Action: &dsa1.Action{
+			Name:       "",
+			Properties: &structpb.Struct{},
+		},
+		Resource: &dsa1.Resource{
+			Type:       "",
+			Id:         "",
+			Properties: &structpb.Struct{},
+		},
+		Context: &structpb.Struct{},
+		Page: &dsa1.Page{
+			NextToken: "",
+		},
+	}
+}

--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	"github.com/aserto-dev/topaz/pkg/cli/cmd/access"
 	"github.com/aserto-dev/topaz/pkg/cli/cmd/authorizer"
 	"github.com/aserto-dev/topaz/pkg/cli/cmd/certs"
 	"github.com/aserto-dev/topaz/pkg/cli/cmd/configure"
@@ -24,8 +25,9 @@ type CLI struct {
 	Run        topaz.RunCmd             `cmd:"" help:"start topaz instance (console mode)"`
 	Templates  templates.TemplateCmd    `cmd:"" help:"template commands"`
 	Console    topaz.ConsoleCmd         `cmd:"" help:"open topaz console in the browser"`
-	Directory  directory.DirectoryCmd   `cmd:"" aliases:"ds" help:"directory commands"`
-	Authorizer authorizer.AuthorizerCmd `cmd:"" aliases:"az" help:"authorizer commands"`
+	Directory  directory.DirectoryCmd   `cmd:"" aliases:"ds" help:"directory service commands"`
+	Authorizer authorizer.AuthorizerCmd `cmd:"" aliases:"az" help:"authorizer service commands"`
+	Access     access.AccessCmd         `cmd:"" aliases:"ac" help:"access service commands "`
 	Certs      certs.CertsCmd           `cmd:"" help:"certificate management"`
 	Install    topaz.InstallCmd         `cmd:"" help:"install topaz container"`
 	Uninstall  topaz.UninstallCmd       `cmd:"" help:"uninstall topaz container"`

--- a/pkg/cli/cmd/directory/checks.go
+++ b/pkg/cli/cmd/directory/checks.go
@@ -1,0 +1,86 @@
+package directory
+
+import (
+	"github.com/aserto-dev/go-directory/aserto/directory/reader/v3"
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+	"github.com/aserto-dev/topaz/pkg/cli/edit"
+	"github.com/aserto-dev/topaz/pkg/cli/fflag"
+	"github.com/aserto-dev/topaz/pkg/cli/jsonx"
+	"github.com/aserto-dev/topaz/pkg/cli/pb"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+type ChecksCmd struct {
+	Request  string `arg:"" type:"string" name:"request" optional:"" help:"json request or file path to check permission request or '-' to read from stdin"`
+	Template bool   `name:"template" short:"t" help:"prints a check permission request template on stdout"`
+	Editor   bool   `name:"edit" short:"e" help:"edit request" hidden:"" type:"fflag.Editor"`
+	dsc.Config
+}
+
+func (cmd *ChecksCmd) Run(c *cc.CommonCtx) error {
+	if cmd.Template {
+		return jsonx.OutputJSONPB(c.StdOut(), cmd.template())
+	}
+
+	client, err := dsc.NewClient(c, &cmd.Config)
+	if err != nil {
+		return errors.Wrap(err, "failed to get directory client")
+	}
+
+	if cmd.Request == "" && cmd.Editor && fflag.Enabled(fflag.Editor) {
+		req, err := edit.Msg(cmd.template())
+		if err != nil {
+			return err
+		}
+		cmd.Request = req
+	}
+
+	if cmd.Request == "" && fflag.Enabled(fflag.Prompter) {
+		return status.Error(codes.Unavailable, "prompter is unavailable for directory checks command")
+	}
+
+	if cmd.Request == "" {
+		return errors.New("request argument is required")
+	}
+
+	var req reader.ChecksRequest
+	err = pb.UnmarshalRequest(cmd.Request, &req)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Reader.Checks(c.Context, &req)
+	if err != nil {
+		return errors.Wrap(err, "checks permission call failed")
+	}
+
+	return jsonx.OutputJSONPB(c.StdOut(), resp)
+}
+
+func (cmd *ChecksCmd) template() proto.Message {
+	return &reader.ChecksRequest{
+		Default: &reader.CheckRequest{
+			ObjectType:  "",
+			ObjectId:    "",
+			Relation:    "",
+			SubjectType: "",
+			SubjectId:   "",
+			Trace:       false,
+		},
+		Checks: []*reader.CheckRequest{
+			{
+				ObjectType:  "",
+				ObjectId:    "",
+				Relation:    "",
+				SubjectType: "",
+				SubjectId:   "",
+				Trace:       false,
+			},
+		},
+	}
+}

--- a/pkg/cli/cmd/directory/directory.go
+++ b/pkg/cli/cmd/directory/directory.go
@@ -1,7 +1,8 @@
 package directory
 
 type DirectoryCmd struct {
-	Check   CheckCmd   `cmd:"" help:"check permission"`
+	Check   CheckCmd   `cmd:"" help:"check single permission"`
+	Checks  ChecksCmd  `cmd:"" help:"check multiple permissions"`
 	Search  SearchCmd  `cmd:"" help:"search relation graph"`
 	Get     GetCmd     `cmd:"" help:"get object|relation|manifest"`
 	Set     SetCmd     `cmd:"" help:"set object|relation|manifest"`

--- a/pkg/cli/prompter/prompter.go
+++ b/pkg/cli/prompter/prompter.go
@@ -186,6 +186,13 @@ func (f *prompt) addFields(msg proto.Message, md protoreflect.MessageDescriptor,
 				continue
 			}
 
+			if strings.HasSuffix(string(fd.FullName()), ".context") {
+				f.form.AddInputField(fieldName, "{ }", 64, nil, func(s string) {
+					_ = f.setProps(msg.ProtoReflect(), fields.Get(c), s)
+				})
+				continue
+			}
+
 			cm := msg.ProtoReflect().Get(fd).Message()
 			_ = f.addFields(cm.Interface(), fields.Get(c).Message(), path)
 

--- a/pkg/cli/prompter/prompter_test.go
+++ b/pkg/cli/prompter/prompter_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/aserto-dev/go-directory/aserto/directory/reader/v3"
 	"github.com/aserto-dev/go-directory/aserto/directory/writer/v3"
 	"github.com/aserto-dev/topaz/pkg/cli/prompter"
+	"github.com/authzen/access.go/api/access/v1"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -56,12 +58,131 @@ func TestPrompter(t *testing.T) {
 		&writer.DeleteRelationRequest{},
 
 		&reader.CheckRequest{},
+		&reader.ChecksRequest{
+			Default: &reader.CheckRequest{},
+			Checks:  []*reader.CheckRequest{},
+		},
+
 		&reader.GetGraphRequest{},
+
+		&access.EvaluationRequest{
+			Subject: &access.Subject{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Action: &access.Action{
+				Name:       "",
+				Properties: &structpb.Struct{},
+			},
+			Resource: &access.Resource{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Context: &structpb.Struct{},
+		},
+		&access.EvaluationsRequest{
+			Subject: &access.Subject{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Action: &access.Action{
+				Name:       "",
+				Properties: &structpb.Struct{},
+			},
+			Resource: &access.Resource{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Context: &structpb.Struct{},
+			Evaluations: []*access.EvaluationRequest{
+				{
+					Subject: &access.Subject{
+						Type:       "",
+						Id:         "",
+						Properties: &structpb.Struct{},
+					},
+					Action: &access.Action{
+						Name:       "",
+						Properties: &structpb.Struct{},
+					},
+					Resource: &access.Resource{
+						Type:       "",
+						Id:         "",
+						Properties: &structpb.Struct{},
+					},
+					Context: &structpb.Struct{},
+				},
+			},
+			Options: &structpb.Struct{},
+		},
+		&access.ActionSearchRequest{
+			Subject: &access.Subject{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Action: &access.Action{
+				Name:       "",
+				Properties: &structpb.Struct{},
+			},
+			Resource: &access.Resource{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Context: &structpb.Struct{},
+			Page:    &access.Page{},
+		},
+		&access.ResourceSearchRequest{
+			Subject: &access.Subject{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Action: &access.Action{
+				Name:       "",
+				Properties: &structpb.Struct{},
+			},
+			Resource: &access.Resource{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Context: &structpb.Struct{},
+			Page:    &access.Page{},
+		},
+		&access.SubjectSearchRequest{
+			Subject: &access.Subject{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Action: &access.Action{
+				Name:       "",
+				Properties: &structpb.Struct{},
+			},
+			Resource: &access.Resource{
+				Type:       "",
+				Id:         "",
+				Properties: &structpb.Struct{},
+			},
+			Context: &structpb.Struct{},
+			Page:    &access.Page{},
+		},
 	}
 
 	for _, req := range reqs {
 		form := prompter.New(req)
-		_ = form.Show()
+		require.NotNil(t, form)
+
+		if err := form.Show(); err != nil {
+			require.ErrorIs(t, err, prompter.ErrCancelled)
+			// require.NoError(t, err)
+		}
 
 		fmt.Fprint(os.Stderr, protojson.MarshalOptions{
 			Multiline:         true,


### PR DESCRIPTION
Add AuthZen access services commands to the topaz CLI

```
topaz access --help
Usage: topaz access (ac) <command> [flags]

access service commands

Commands:
  access (ac) evaluation
  access (ac) evaluations
  access (ac) subject-search
  access (ac) resource-search
  access (ac) action-search

Flags:
  -h, --help         Show context-sensitive help.
  -N, --no-check     disable local container status check ($TOPAZ_NO_CHECK)
      --no-color     disable colored terminal output ($TOPAZ_NO_COLOR)
  -v, --verbosity    log level
```

Add directory services `checks` command to topaz CLI

```
topaz directory checks --help
Usage: topaz directory (ds) checks [<request>] [flags]

check multiple permissions

Arguments:
  [<request>]    json request or file path to check permission request or '-' to read from stdin

Flags:
  -h, --help                     Show context-sensitive help.
  -N, --no-check                 disable local container status check ($TOPAZ_NO_CHECK)
      --no-color                 disable colored terminal output ($TOPAZ_NO_COLOR)
  -v, --verbosity                log level

  -t, --template                 prints a check permission request template on stdout
  -H, --host="localhost:9292"    directory service address ($TOPAZ_DIRECTORY_SVC)
  -k, --api-key=""               directory API key ($TOPAZ_DIRECTORY_KEY)
  -i, --insecure                 skip TLS verification ($TOPAZ_INSECURE)
  -P, --plaintext                use plain-text HTTP/2 (no TLS) ($TOPAZ_PLAINTEXT)
      --tenant-id=""             ($ASERTO_TENANT_ID)
      --headers=KEY=VALUE;...    additional headers to send to the directory service
                                 ($TOPAZ_DIRECTORY_HEADERS)
  -T, --timeout=5s               command timeout ($TOPAZ_TIMEOUT)
```