### PR TITLE
add topaz templates download | apply commands

### DIFF
--- a/pkg/cli/cmd/templates/apply.go
+++ b/pkg/cli/cmd/templates/apply.go
@@ -1,0 +1,11 @@
+package templates
+
+import (
+	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+)
+
+type ApplyTemplateCmd struct {
+	Name  string `arg:"" required:"" help:"template name"`
+	Force bool   `flag:"" short:"f" default:"false" required:"false" help:"skip confirmation prompt"`
+	dsc.Config
+}

--- a/pkg/cli/cmd/templates/apply.go
+++ b/pkg/cli/cmd/templates/apply.go
@@ -1,11 +1,159 @@
 package templates
 
 import (
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/aserto-dev/go-edge-ds/pkg/fs"
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	azc "github.com/aserto-dev/topaz/pkg/cli/clients/authorizer"
 	dsc "github.com/aserto-dev/topaz/pkg/cli/clients/directory"
+	"github.com/aserto-dev/topaz/pkg/cli/cmd/common"
+	"github.com/aserto-dev/topaz/pkg/cli/cmd/directory"
+	"github.com/pkg/errors"
 )
 
 type ApplyTemplateCmd struct {
 	Name  string `arg:"" required:"" help:"template name"`
 	Force bool   `flag:"" short:"f" default:"false" required:"false" help:"skip confirmation prompt"`
+
 	dsc.Config
+}
+
+func (cmd *ApplyTemplateCmd) Run(c *cc.CommonCtx) error {
+	templateDir := path.Join(cc.GetTopazTemplateDir(), cmd.Name)
+	if !fs.DirExists(templateDir) {
+		return errors.Errorf("directory %q does not exist", templateDir)
+	}
+
+	if !cmd.Force {
+		c.Con().Warn().Msg("Applying this template will reset the topaz directory content.")
+
+		if !common.PromptYesNo("Do you want to continue?", false) {
+			return nil
+		}
+	}
+
+	if err := cmd.deleteManifest(c); err != nil {
+		return err
+	}
+
+	if err := cmd.setManifest(c); err != nil {
+		return err
+	}
+
+	if err := cmd.importData(c); err != nil {
+		return err
+	}
+
+	if err := cmd.execAssertions(c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *ApplyTemplateCmd) deleteManifest(c *cc.CommonCtx) error {
+	command := directory.DeleteManifestCmd{
+		Force:  true,
+		Config: cmd.Config,
+	}
+
+	return command.Run(c)
+}
+
+func (cmd *ApplyTemplateCmd) setManifest(c *cc.CommonCtx) error {
+	manifestDir := path.Join(cc.GetTopazTemplateDir(), cmd.Name, "model")
+	if !fs.DirExists(manifestDir) {
+		return errors.Errorf("directory %q does not exist", manifestDir)
+	}
+
+	manifest := filepath.Join(manifestDir, "manifest.yaml")
+	if !fs.FileExists(manifest) {
+		return errors.Errorf("file %q does not exist", manifest)
+	}
+
+	command := directory.SetManifestCmd{
+		Path:   manifest,
+		Config: cmd.Config,
+	}
+
+	return command.Run(c)
+}
+
+func (cmd *ApplyTemplateCmd) importData(c *cc.CommonCtx) error {
+	dataDir := path.Join(cc.GetTopazTemplateDir(), cmd.Name, "data")
+	if !fs.DirExists(dataDir) {
+		return errors.Errorf("directory %q does not exist", dataDir)
+	}
+
+	command := directory.ImportCmd{
+		Directory: dataDir,
+		Config:    cmd.Config,
+	}
+
+	return command.Run(c)
+}
+
+func (cmd *ApplyTemplateCmd) execAssertions(c *cc.CommonCtx) error {
+	assertionsDir := path.Join(cc.GetTopazTemplateDir(), cmd.Name, "assertions")
+	if !fs.DirExists(assertionsDir) {
+		return errors.Errorf("directory %q does not exist", assertionsDir)
+	}
+
+	entries, err := os.ReadDir(assertionsDir)
+	if err != nil {
+		return err
+	}
+
+	tests := []string{}
+
+	for _, v := range entries {
+		if v.IsDir() {
+			continue
+		}
+
+		tests = append(tests, filepath.Join(assertionsDir, v.Name()))
+	}
+
+	runner, err := common.NewTestRunner(
+		c,
+		&common.TestExecCmd{
+			Files:   tests,
+			Stdin:   false,
+			Summary: true,
+			Format:  "table",
+			Desc:    "on-error",
+		},
+		&azc.Config{
+			Host:      cc.AuthorizerSvc(),
+			APIKey:    cmd.Config.APIKey,
+			Token:     cmd.Config.Token,
+			Insecure:  cmd.Config.Insecure,
+			Plaintext: cmd.Config.Plaintext,
+			TenantID:  cmd.Config.TenantID,
+			Headers:   cmd.Config.Headers,
+			Timeout:   cmd.Config.Timeout,
+		},
+		&dsc.Config{
+			Host:      cmd.Config.Host,
+			APIKey:    cmd.Config.APIKey,
+			Token:     cmd.Config.Token,
+			Insecure:  cmd.Config.Insecure,
+			Plaintext: cmd.Config.Plaintext,
+			TenantID:  cmd.Config.TenantID,
+			Headers:   cmd.Config.Headers,
+			Timeout:   cmd.Config.Timeout,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := runner.Run(c); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cli/cmd/templates/download.go
+++ b/pkg/cli/cmd/templates/download.go
@@ -1,0 +1,8 @@
+package templates
+
+type DownloadTemplateCmd struct {
+	Name         string `arg:"" required:"" help:"template name"`
+	Force        bool   `flag:"" short:"f" default:"false" required:"false" help:"skip confirmation prompt"`
+	TemplatesURL string `optional:"" default:"${topaz_tmpl_url}" env:"TOPAZ_TMPL_URL" help:"URL of template catalog"`
+	ConfigName   string `optional:"" help:"set config name"`
+}

--- a/pkg/cli/cmd/templates/download.go
+++ b/pkg/cli/cmd/templates/download.go
@@ -1,8 +1,99 @@
 package templates
 
+import (
+	"path"
+
+	"github.com/aserto-dev/topaz/pkg/cli/cc"
+	"github.com/aserto-dev/topaz/pkg/cli/cmd/common"
+	"github.com/pkg/errors"
+)
+
 type DownloadTemplateCmd struct {
 	Name         string `arg:"" required:"" help:"template name"`
 	Force        bool   `flag:"" short:"f" default:"false" required:"false" help:"skip confirmation prompt"`
 	TemplatesURL string `optional:"" default:"${topaz_tmpl_url}" env:"TOPAZ_TMPL_URL" help:"URL of template catalog"`
 	ConfigName   string `optional:"" help:"set config name"`
+}
+
+func (cmd *DownloadTemplateCmd) Run(c *cc.CommonCtx) error {
+	if cmd.ConfigName == "" {
+		cmd.ConfigName = cmd.Name
+	}
+
+	if cmd.ConfigName != "" && !common.RestrictedNamePattern.MatchString(cmd.ConfigName) {
+		return errors.Errorf("%s name must match pattern %s", cmd.Name, common.RestrictedNamePattern.String())
+	}
+
+	topazTemplateDir := cc.GetTopazTemplateDir()
+
+	catalog, err := getCatalog(cmd.TemplatesURL)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := catalog[cmd.Name]; !ok {
+		return errors.Errorf("template %s not found", cmd.Name)
+	}
+
+	tmpl, err := getTemplate(cmd.Name, cmd.TemplatesURL)
+	if err != nil {
+		return err
+	}
+
+	// manifest
+	{
+		manifestDir := path.Join(topazTemplateDir, cmd.ConfigName, "model")
+
+		s, err := download(tmpl.AbsURL(tmpl.Assets.Manifest), manifestDir)
+		if err != nil {
+			return err
+		}
+
+		c.Con().Msg(s)
+	}
+
+	// data
+	{
+		dataDir := path.Join(topazTemplateDir, cmd.ConfigName, "data")
+
+		// identity data
+		{
+			for _, url := range tmpl.Assets.IdentityData {
+				s, err := download(tmpl.AbsURL(url), dataDir)
+				if err != nil {
+					return err
+				}
+
+				c.Con().Msg(s)
+			}
+		}
+
+		// domain data
+		{
+			for _, url := range tmpl.Assets.DomainData {
+				s, err := download(tmpl.AbsURL(url), dataDir)
+				if err != nil {
+					return err
+				}
+
+				c.Con().Msg(s)
+			}
+		}
+	}
+
+	// test data
+	{
+		testDir := path.Join(topazTemplateDir, cmd.ConfigName, "assertions")
+
+		for _, url := range tmpl.Assets.Assertions {
+			s, err := download(tmpl.AbsURL(url), testDir)
+			if err != nil {
+				return err
+			}
+
+			c.Con().Msg(s)
+		}
+	}
+
+	return nil
 }

--- a/pkg/cli/cmd/templates/template.go
+++ b/pkg/cli/cmd/templates/template.go
@@ -16,9 +16,11 @@ import (
 )
 
 type TemplateCmd struct {
-	List    ListTemplatesCmd   `cmd:"" help:"list template"`
-	Install InstallTemplateCmd `cmd:"" help:"install template"`
-	Verify  VerifyTemplateCmd  `cmd:"" help:"verify template content links" hidden:""`
+	List     ListTemplatesCmd    `cmd:"" help:"list template"`
+	Install  InstallTemplateCmd  `cmd:"" help:"install template"`
+	Verify   VerifyTemplateCmd   `cmd:"" help:"verify template content links" hidden:""`
+	Download DownloadTemplateCmd `cmd:"" help:"download template" hidden:""`
+	Apply    ApplyTemplateCmd    `cmd:"" help:"apply template to directory" hidden:""`
 }
 
 const (

--- a/pkg/cli/cmd/templates/verify.go
+++ b/pkg/cli/cmd/templates/verify.go
@@ -12,11 +12,12 @@ import (
 )
 
 type VerifyTemplateCmd struct {
+	Name         string `arg:"" optional:"" help:"template name"`
 	TemplatesURL string `optional:"" default:"${topaz_tmpl_url}" env:"TOPAZ_TMPL_URL" help:"URL of template catalog"`
 }
 
 func (cmd *VerifyTemplateCmd) Run(c *cc.CommonCtx) error {
-	ctlg, err := getCatalog(cmd.TemplatesURL)
+	catalog, err := getCatalog(cmd.TemplatesURL)
 	if err != nil {
 		return err
 	}
@@ -27,7 +28,11 @@ func (cmd *VerifyTemplateCmd) Run(c *cc.CommonCtx) error {
 	tab := table.New(c.StdOut()).WithColumns("template", "asset", "exists", "parsed", "error")
 	tab.WithTableNoAutoWrapText()
 
-	for tmplName := range ctlg {
+	for tmplName := range catalog {
+		if cmd.Name != "" && tmplName != cmd.Name {
+			continue
+		}
+
 		tmpl, err := getTemplate(tmplName, cmd.TemplatesURL)
 		if err != nil {
 			return err


### PR DESCRIPTION
`topaz templates download` downloads the template files to the local template directory.

`topaz templates apply` applies the local template (manifest and data) files to the directory and executes the assertions.
