### PR TITLE
use correct FullMethodName

### DIFF
--- a/pkg/cli/cmd/authorizer/get.go
+++ b/pkg/cli/cmd/authorizer/get.go
@@ -28,7 +28,7 @@ func (cmd *GetPolicyCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
-	if err := cmd.Config.Invoke(c.Context, authorizer.Authorizer_Is_FullMethodName, &cmd.req, &cmd.resp); err != nil {
+	if err := cmd.Config.Invoke(c.Context, authorizer.Authorizer_GetPolicy_FullMethodName, &cmd.req, &cmd.resp); err != nil {
 		return err
 	}
 

--- a/pkg/cli/cmd/authorizer/list.go
+++ b/pkg/cli/cmd/authorizer/list.go
@@ -31,7 +31,7 @@ func (cmd *ListPoliciesCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
-	if err := cmd.Config.Invoke(c.Context, authorizer.Authorizer_Is_FullMethodName, &cmd.req, &cmd.resp); err != nil {
+	if err := cmd.Config.Invoke(c.Context, authorizer.Authorizer_ListPolicies_FullMethodName, &cmd.req, &cmd.resp); err != nil {
 		return err
 	}
 

--- a/pkg/cli/cmd/authorizer/query.go
+++ b/pkg/cli/cmd/authorizer/query.go
@@ -27,7 +27,7 @@ func (cmd *QueryCmd) Run(c *cc.CommonCtx) error {
 		return err
 	}
 
-	if err := cmd.Config.Invoke(c.Context, authorizer.Authorizer_Is_FullMethodName, &cmd.req, &cmd.resp); err != nil {
+	if err := cmd.Config.Invoke(c.Context, authorizer.Authorizer_Query_FullMethodName, &cmd.req, &cmd.resp); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use the correct `FullMethodName` for `az get policy`, `az list policies`, and `az query`