### PR TITLE
fix edge plugin

### DIFF
--- a/pkg/cc/config/schema/config.json
+++ b/pkg/cc/config/schema/config.json
@@ -178,6 +178,11 @@
                     "description": "disable TLS and use a plaintext connection",
                     "default": "false"
                 },
+                "no_proxy": {
+                    "type": "boolean",
+                    "description": "bypass any configured HTTP proxy",
+                    "default": "false"
+                },
                 "headers": {
                     "type": "object",
                     "description": "map of additional gRPC headers",

--- a/pkg/cc/config/schema/config.yaml
+++ b/pkg/cc/config/schema/config.yaml
@@ -32,6 +32,7 @@ remote_directory:
   ca_cert_path: ""
   timeout_in_seconds: 5
   no_tls: false
+  no_proxy: false
   headers:
     aserto-account-id: "00000000-1111-2222-3333-444455556666"
 

--- a/plugins/edge/plugin.go
+++ b/plugins/edge/plugin.go
@@ -33,17 +33,22 @@ const (
 )
 
 type Config struct {
-	Enabled           bool          `json:"enabled"`
-	Addr              string        `json:"addr"`
-	APIKey            string        `json:"apikey"`
-	TenantID          string        `json:"tenant_id,omitempty"`
-	Timeout           int           `json:"timeout"`
-	SyncInterval      int           `json:"sync_interval"`
-	Insecure          bool          `json:"insecure"`
-	SessionID         string        `json:"session_id,omitempty"`
-	ConnectionTimeout time.Duration `json:"-"`
-	// Deprecated: No longer used.
-	PageSize int `json:"page_size,omitempty"`
+	Enabled           bool              `json:"enabled"`              //
+	Addr              string            `json:"addr"`                 //
+	APIKey            string            `json:"apikey"`               //
+	TenantID          string            `json:"tenant_id,omitempty"`  //
+	Timeout           int               `json:"timeout"`              // timeout in seconds.
+	SyncInterval      int               `json:"sync_interval"`        // interval in minutes.
+	Insecure          bool              `json:"insecure"`             //
+	SessionID         string            `json:"session_id,omitempty"` // deprecated: no longer used.
+	ConnectionTimeout time.Duration     `json:"-"`                    // mapped at runtime to timeout * time.Second.
+	PageSize          int               `json:"page_size,omitempty"`  // deprecated: no longer used.
+	ClientCertPath    string            `json:"client_cert_path"`     //
+	ClientKeyPath     string            `json:"client_key_path"`      //
+	CACertPath        string            `json:"ca_cert_path"`         //
+	NoTLS             bool              `json:"no_tls"`               //
+	NoProxy           bool              `json:"no_proxy"`             //
+	Headers           map[string]string `json:"headers"`              //
 }
 
 type Plugin struct {
@@ -351,11 +356,16 @@ func (p *Plugin) exec(ctx context.Context, ds *directory.Directory, conn *grpc.C
 
 func (p *Plugin) remoteDirectoryClient() (*grpc.ClientConn, error) {
 	cfg := &client.Config{
-		Address:  p.config.Addr,
-		Insecure: p.config.Insecure,
-		APIKey:   p.config.APIKey,
-		TenantID: p.config.TenantID,
-		Headers:  p.topazConfig.DirectoryResolver.Headers,
+		Address:        p.config.Addr,           //
+		APIKey:         p.config.APIKey,         //
+		TenantID:       p.config.TenantID,       //
+		ClientCertPath: p.config.ClientCertPath, //
+		ClientKeyPath:  p.config.ClientKeyPath,  //
+		CACertPath:     p.config.CACertPath,     //
+		Insecure:       p.config.Insecure,       //
+		NoTLS:          p.config.NoTLS,          //
+		NoProxy:        p.config.NoProxy,        //
+		Headers:        p.config.Headers,        //
 	}
 
 	conn, err := cfg.Connect()


### PR DESCRIPTION
Fix authorizer edge plugin

* Add support to configure:
  * NoTLS
  * NoProxy
  * Headers
  * Certs
* Update the config JSON schema file to include new fields.
 
Full edge configuration section now looks like this:

```
      aserto_edge:
        enabled: true
        addr: localhost:9999
        apikey: ""
        tenant_id: ""
        insecure: false
        no_tls: true
        no_proxy: false
        sync_interval: 5
        timeout: 5
        client_cert_path: ""
        client_key_path: ""
        ca_cert_path: ""
```

