### PR TITLE
fix template install policy registry

### DIFF
--- a/pkg/cc/config/generator.go
+++ b/pkg/cc/config/generator.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/aserto-dev/topaz/pkg/cli/cc"
 	"github.com/aserto-dev/topaz/pkg/cli/x"
@@ -34,7 +35,15 @@ func (g *Generator) WithPolicyName(policyName string) *Generator {
 }
 
 func (g *Generator) WithResource(resource string) *Generator {
+	g.PolicyRegistry = "https://ghcr.io" // set to original default
+
+	policyRegistry, _, found := strings.Cut(resource, "/")
+	if found && policyRegistry != "" {
+		g.PolicyRegistry = "https://" + policyRegistry
+	}
+
 	g.Resource = resource
+
 	return g
 }
 

--- a/pkg/cc/config/templates.go
+++ b/pkg/cc/config/templates.go
@@ -2,6 +2,7 @@ package config
 
 type templateParams struct {
 	Version           int
+	PolicyRegistry    string
 	PolicyName        string
 	Resource          string
 	Authorization     string
@@ -49,13 +50,13 @@ opa:
     skip_verification: true
   config:
     services:
-      ghcr:
-        url: https://ghcr.io
+      policy-registry:
+        url: "{{ .PolicyRegistry }}"
         type: "oci"
         response_header_timeout_seconds: 5
     bundles:
       {{ .PolicyName }}:
-        service: ghcr
+        service: policy-registry
         resource: "{{ .Resource }}"
         persist: false
         config:


### PR DESCRIPTION
Fix `topaz template install` using a custom template, which does not use `ghcr.io`.

* Extract the policy registry from the resource passed in, instead of using the hardcoded `https://ghcr.io`
* Fallback to use ghcr.io when the extraction fails

With this change, existing templates continue to work, all template tests pass, and no updates are required.

The complete fix requires adding a policy registry field, which will require updating all existing templates as well.
