### PR TITLE
add AuthZEN evaluation assertions to templates

### DIFF
--- a/assets/templates-v32.json
+++ b/assets/templates-v32.json
@@ -33,7 +33,7 @@
   },
   "api-auth": {
     "title": "API Authorization",
-    "short_description": "Template for authorization of servics and endpoints",
+    "short_description": "Template for authorization of services and endpoints",
     "description": "The API Authorization template defines services and endpoints. You can import an OpenAPI spec and automatically generate services, endpoints, and groups for entitling users to a whole service, specific endpoints, or certain HTTP methods. You can evolve it to fit your needs.",
     "docs_url": "https://docs.aserto.com/docs/quickstarts/api-auth/overview",
     "topaz_url": "v32/api-auth.json",

--- a/assets/templates-v33.json
+++ b/assets/templates-v33.json
@@ -33,7 +33,7 @@
   },
   "api-auth": {
     "title": "API Authorization",
-    "short_description": "Template for authorization of servics and endpoints",
+    "short_description": "Template for authorization of services and endpoints",
     "description": "The API Authorization template defines services and endpoints. You can import an OpenAPI spec and automatically generate services, endpoints, and groups for entitling users to a whole service, specific endpoints, or certain HTTP methods. You can evolve it to fit your needs.",
     "docs_url": "https://docs.aserto.com/docs/quickstarts/api-auth/overview",
     "topaz_url": "v33/api-auth.json",

--- a/assets/templates.json
+++ b/assets/templates.json
@@ -33,7 +33,7 @@
   },
   "api-auth": {
     "title": "API Authorization",
-    "short_description": "Template for authorization of servics and endpoints",
+    "short_description": "Template for authorization of services and endpoints",
     "description": "The API Authorization template defines services and endpoints. You can import an OpenAPI spec and automatically generate services, endpoints, and groups for entitling users to a whole service, specific endpoints, or certain HTTP methods. You can evolve it to fit your needs.",
     "docs_url": "https://docs.aserto.com/docs/quickstarts/api-auth/overview",
     "topaz_url": "v32/api-auth.json",

--- a/assets/v32/api-auth.json
+++ b/assets/v32/api-auth.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "api-auth/test/api-auth_assertions.json",
-            "api-auth/test/api-auth_decisions.json"
+            "api-auth/test/api-auth_decisions.json",
+            "api-auth/test/api-auth_evaluations.json"
         ]
     }
 }

--- a/assets/v32/api-auth/test/api-auth_evaluations.json
+++ b/assets/v32/api-auth/test/api-auth_evaluations.json
@@ -1,0 +1,564 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/assets/v32/gdrive.json
+++ b/assets/v32/gdrive.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "gdrive/test/gdrive_assertions.json",
-            "gdrive/test/gdrive_decisions.json"
+            "gdrive/test/gdrive_decisions.json",
+            "gdrive/test/gdrive_evaluations.json"
         ]
     }
 }

--- a/assets/v32/gdrive/test/gdrive_evaluations.json
+++ b/assets/v32/gdrive/test/gdrive_evaluations.json
@@ -1,0 +1,2996 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/assets/v32/github.json
+++ b/assets/v32/github.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "github/test/github_assertions.json",
-            "github/test/github_decisions.json"
+            "github/test/github_decisions.json",
+            "github/test/github_evaluations.json"
         ]
     }
 }

--- a/assets/v32/github/test/github_evaluations.json
+++ b/assets/v32/github/test/github_evaluations.json
@@ -1,0 +1,180 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_triage"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_triage"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "citadel.missions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "citadel.missions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "citadel.missions"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/assets/v32/multi-tenant.json
+++ b/assets/v32/multi-tenant.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "multi-tenant/test/multi-tenant_assertions.json",
-            "multi-tenant/test/multi-tenant_decisions.json"
+            "multi-tenant/test/multi-tenant_decisions.json",
+            "multi-tenant/test/multi-tenant_evaluations.json"
         ]
     }
 }

--- a/assets/v32/multi-tenant/test/multi-tenant_evaluations.json
+++ b/assets/v32/multi-tenant/test/multi-tenant_evaluations.json
@@ -1,0 +1,3716 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "system",
+          "id": "system"
+        },
+        "action": {
+          "name": "system"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "system",
+          "id": "system"
+        },
+        "action": {
+          "name": "system"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    }
+  ]
+}

--- a/assets/v32/simple-rbac.json
+++ b/assets/v32/simple-rbac.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "simple-rbac/assertions.json",
-            "simple-rbac/decisions.json"
+            "simple-rbac/decisions.json",
+            "simple-rbac/evaluations.json"
         ]
     }
 }

--- a/assets/v32/simple-rbac/evaluations.json
+++ b/assets/v32/simple-rbac/evaluations.json
@@ -1,0 +1,20 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "member"
+        },
+        "resource": {
+          "type": "group",
+          "id": "admin"
+        }
+      },
+      "expected": true
+    }
+  ]
+}

--- a/assets/v32/slack.json
+++ b/assets/v32/slack.json
@@ -17,7 +17,8 @@
       ],
       "assertions": [
           "slack/test/slack_assertions.json",
-          "slack/test/slack_decisions.json"
+          "slack/test/slack_decisions.json",
+          "slack/test/slack_evaluations.json"
       ]
   }
 }

--- a/assets/v32/slack/test/slack_evaluations.json
+++ b/assets/v32/slack/test/slack_evaluations.json
@@ -1,0 +1,116 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "channels_admin"
+        },
+        "resource": {
+          "type": "workspace",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "channels_admin"
+        },
+        "resource": {
+          "type": "workspace",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.gossip"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.general"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.general"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/assets/v33/api-auth.json
+++ b/assets/v33/api-auth.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "api-auth/test/api-auth_assertions.json",
-            "api-auth/test/api-auth_decisions.json"
+            "api-auth/test/api-auth_decisions.json",
+            "api-auth/test/api-auth_evaluations.json"
         ]
     }
 }

--- a/assets/v33/api-auth/test/api-auth_evaluations.json
+++ b/assets/v33/api-auth/test/api-auth_evaluations.json
@@ -1,0 +1,564 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:DELETE:/v1/todos/{todoId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:GET:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "todo:POST:/v1/todos"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "rick-and-morty:GET:/v1/characters"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:GET:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:POST:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_invoke"
+        },
+        "resource": {
+          "type": "endpoint",
+          "id": "petstore:DELETE:/pet/{petId}"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/assets/v33/gdrive.json
+++ b/assets/v33/gdrive.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "gdrive/test/gdrive_assertions.json",
-            "gdrive/test/gdrive_decisions.json"
+            "gdrive/test/gdrive_decisions.json",
+            "gdrive/test/gdrive_evaluations.json"
         ]
     }
 }

--- a/assets/v33/gdrive/test/gdrive_evaluations.json
+++ b/assets/v33/gdrive/test/gdrive_evaluations.json
@@ -1,0 +1,2996 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "root"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "rick"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "summer"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "jerry"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "folder",
+          "id": "morty.shared"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "secrets"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "groceries"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "rick.inventions"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_share"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "doc",
+          "id": "morty.shared.notes"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/assets/v33/github/test/github_evaluations.json
+++ b/assets/v33/github/test/github_evaluations.json
@@ -1,0 +1,180 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_triage"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_triage"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "smiths.budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "citadel.missions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "citadel.missions"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "repo",
+          "id": "citadel.missions"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/assets/v33/multi-tenant.json
+++ b/assets/v33/multi-tenant.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "multi-tenant/test/multi-tenant_assertions.json",
-            "multi-tenant/test/multi-tenant_decisions.json"
+            "multi-tenant/test/multi-tenant_decisions.json",
+            "multi-tenant/test/multi-tenant_evaluations.json"
         ]
     }
 }

--- a/assets/v33/multi-tenant/test/multi-tenant_evaluations.json
+++ b/assets/v33/multi-tenant/test/multi-tenant_evaluations.json
@@ -1,0 +1,3716 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_tenant"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "system",
+          "id": "system"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "admin"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "editor"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "viewer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_administer"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_edit"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_view"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_manage_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_list_members"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_leave_tenant"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_create_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read_resources"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "citadel-adventures"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "owner"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "reader"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_delete"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_write"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "identity",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "can_read"
+        },
+        "resource": {
+          "type": "resource",
+          "id": "smiths-budget"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "system",
+          "id": "system"
+        },
+        "action": {
+          "name": "system"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "system",
+          "id": "system"
+        },
+        "action": {
+          "name": "system"
+        },
+        "resource": {
+          "type": "tenant",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    }
+  ]
+}

--- a/assets/v33/simple-rbac.json
+++ b/assets/v33/simple-rbac.json
@@ -17,7 +17,8 @@
         ],
         "assertions": [
             "simple-rbac/assertions.json",
-            "simple-rbac/decisions.json"
+            "simple-rbac/decisions.json",
+            "simple-rbac/evaluations.json"
         ]
     }
 }

--- a/assets/v33/simple-rbac/evaluations.json
+++ b/assets/v33/simple-rbac/evaluations.json
@@ -1,0 +1,20 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "member"
+        },
+        "resource": {
+          "type": "group",
+          "id": "admin"
+        }
+      },
+      "expected": true
+    }
+  ]
+}

--- a/assets/v33/slack.json
+++ b/assets/v33/slack.json
@@ -17,7 +17,8 @@
       ],
       "assertions": [
           "slack/test/slack_assertions.json",
-          "slack/test/slack_decisions.json"
+          "slack/test/slack_decisions.json",
+          "slack/test/slack_evaluations.json"
       ]
   }
 }

--- a/assets/v33/slack/test/slack_evaluations.json
+++ b/assets/v33/slack/test/slack_evaluations.json
@@ -1,0 +1,116 @@
+{
+  "assertions": [
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        },
+        "action": {
+          "name": "channels_admin"
+        },
+        "resource": {
+          "type": "workspace",
+          "id": "smiths"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        },
+        "action": {
+          "name": "channels_admin"
+        },
+        "resource": {
+          "type": "workspace",
+          "id": "smiths"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.citadel"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.citadel"
+        }
+      },
+      "expected": false
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.gossip"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.general"
+        }
+      },
+      "expected": true
+    },
+    {
+      "evaluation": {
+        "subject": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        },
+        "action": {
+          "name": "writer"
+        },
+        "resource": {
+          "type": "channel",
+          "id": "smiths.general"
+        }
+      },
+      "expected": false
+    }
+  ]
+}

--- a/scripts/check2evaluation.sh
+++ b/scripts/check2evaluation.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+jq '{
+  assertions: [
+    .assertions[] |
+    {
+      evaluation: {
+        subject: {
+          type: .check.subject_type,
+          id: .check.subject_id
+        },
+        action: {
+          name: .check.relation
+        },
+        resource: {
+          type: .check.object_type,
+          id: .check.object_id
+        }
+      },
+      expected: .expected
+    }
+  ]
+}' $1 


### PR DESCRIPTION
This PR adds AuthZEN-style evaluation-style authorization assertions to the templates.

https://openid.github.io/authzen/#name-access-evaluation-api

```
"assertions": [
    {
      "evaluation": {
        "subject": {
          "type": "identity",
          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
        },
        "action": {
          "name": "GET"
        },
        "resource": {
          "type": "route",
          "id": "/users/{userId}"
        }
      },
      "expected": true
    }
]
```