### PR TITLE
upd golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ permissions:
 env:
   PRE_RELEASE: ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
   GO_RELEASER_VER: "v2.14.1"
-  GO_LANGCI_LINT_VER: "v2.11.4"
+  GO_LANGCI_LINT_VER: "v2.12.2"
   GO_TESTSUM_VER: "1.13.0"
   SYFT_VER: "v1.13.0"
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ linters:
     - exhaustive
     - forbidigo
     - gochecknoglobals # no configuration options
+    - gomodguard # deprecated, replaced by gomodguard_v2
     - nilnil
     - nlreturn # redundant with wsl
     - noinlineerr
@@ -29,7 +30,7 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
-
+  
   settings:
     cyclop:
       max-complexity: 12
@@ -51,10 +52,6 @@ linters:
       disable-all: true
       enabled-checks:
         - commentedOutCode
-
-    gomoddirectives:
-      replace-allow-list:
-        - github.com/slok/go-http-metrics
 
     gosec:
       excludes:
@@ -125,6 +122,10 @@ linters:
       - path: internal/eds/tests/
         linters:
           - dupl
+          - goconst
+      - path: topazd/tests
+        linters:
+          - goconst
 
 formatters:
   enable:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aserto-dev/topaz
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/internal/eds/pkg/datasync/watermark.go
+++ b/internal/eds/pkg/datasync/watermark.go
@@ -110,8 +110,8 @@ func (s *Sync) setWatermark(ts *timestamppb.Timestamp) error {
 		return err
 	}
 
-	wm.ObjectCount = uint(objStats.KeyN)   //nolint:gosec // G115: integer overflow conversion int -> uint
-	wm.RelationCount = uint(relStats.KeyN) //nolint:gosec // G115: integer overflow conversion int -> uint
+	wm.ObjectCount = uint(objStats.KeyN)
+	wm.RelationCount = uint(relStats.KeyN)
 
 	wm.TotalCount = wm.ObjectCount + wm.RelationCount
 

--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ EXT_TMP_DIR        := ${EXT_DIR}/tmp
 GO_VER             := 1.26
 SVU_VER            := 3.3.0
 GOTESTSUM_VER      := 1.13.0
-GOLANGCI-LINT_VER  := 2.11.4
+GOLANGCI-LINT_VER  := 2.12.2
 GORELEASER_VER     := 2.14.1
 SYFT_VER           := 1.13.0
 

--- a/topaz/certs/generator.go
+++ b/topaz/certs/generator.go
@@ -59,6 +59,8 @@ func GenerateCerts(force bool, dnsNames []string, certPaths ...*CertPaths) error
 	return generate(dnsNames, certPaths...)
 }
 
+const generated string = "generated"
+
 func generate(dnsNames []string, certPaths ...*CertPaths) error {
 	logger := zerolog.Nop()
 	ctx := logger.WithContext(context.Background())
@@ -82,9 +84,9 @@ func generate(dnsNames []string, certPaths ...*CertPaths) error {
 			return errors.Wrap(err, "failed to create dev certs")
 		}
 
-		data = append(data, []any{filepath.Base(certPaths.CA), "generated"})
-		data = append(data, []any{filepath.Base(certPaths.Cert), "generated"})
-		data = append(data, []any{filepath.Base(certPaths.Key), "generated"})
+		data = append(data, []any{filepath.Base(certPaths.CA), generated})
+		data = append(data, []any{filepath.Base(certPaths.Cert), generated})
+		data = append(data, []any{filepath.Base(certPaths.Key), generated})
 	}
 
 	tab.Bulk(data)

--- a/topaz/cmd/authorizer/authorizer.go
+++ b/topaz/cmd/authorizer/authorizer.go
@@ -1,5 +1,9 @@
 package authorizer
 
+const (
+	allowed string = "allowed"
+)
+
 type AuthorizerCmd struct {
 	CheckDecision EvalCmd         `cmd:"" name:"eval" help:"evaluate policy decision"`
 	ExecQuery     QueryCmd        `cmd:"" name:"query" help:"execute query"`

--- a/topaz/cmd/authorizer/decisiontree.go
+++ b/topaz/cmd/authorizer/decisiontree.go
@@ -42,7 +42,7 @@ func (cmd *DecisionTreeCmd) template() proto.Message {
 	return &authorizer.DecisionTreeRequest{
 		PolicyContext: &api.PolicyContext{
 			Path:      "",
-			Decisions: []string{"allowed"},
+			Decisions: []string{allowed},
 		},
 		IdentityContext: &api.IdentityContext{
 			Identity: "",

--- a/topaz/cmd/authorizer/eval.go
+++ b/topaz/cmd/authorizer/eval.go
@@ -41,7 +41,7 @@ func (cmd *EvalCmd) template() proto.Message {
 	return &authorizer.IsRequest{
 		PolicyContext: &api.PolicyContext{
 			Path:      "",
-			Decisions: []string{"allowed"},
+			Decisions: []string{allowed},
 		},
 		IdentityContext: &api.IdentityContext{
 			Identity: "",

--- a/topaz/cmd/authorizer/query.go
+++ b/topaz/cmd/authorizer/query.go
@@ -49,7 +49,7 @@ func (cmd *QueryCmd) template() proto.Message {
 		},
 		PolicyContext: &api.PolicyContext{
 			Path:      "",
-			Decisions: []string{"allowed"},
+			Decisions: []string{allowed},
 		},
 		IdentityContext: &api.IdentityContext{
 			Identity: "",

--- a/topaz/cmd/common/testrunner.go
+++ b/topaz/cmd/common/testrunner.go
@@ -24,6 +24,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+const (
+	skipped string = "SKIPPED"
+)
+
 var (
 	ErrSkippedAuthorizerAssertion = cerr.NewAsertoError("T10001", codes.Internal, http.StatusInternalServerError, "no authorizer client")
 	ErrSkippedDirectoryAssertion  = cerr.NewAsertoError("T10002", codes.Internal, http.StatusInternalServerError, "no directory client")
@@ -258,7 +262,7 @@ func checkV3(ctx context.Context, c *dsc.Client, msg *structpb.Value) *CheckResu
 			Outcome:  false,
 			Duration: 0,
 			Err:      ErrSkippedDirectoryAssertion,
-			Str:      "SKIPPED",
+			Str:      skipped,
 		}
 	}
 
@@ -287,7 +291,7 @@ func checkPermissionV3(ctx context.Context, c *dsc.Client, msg *structpb.Value) 
 			Outcome:  false,
 			Duration: 0,
 			Err:      ErrSkippedDirectoryAssertion,
-			Str:      "SKIPPED",
+			Str:      skipped,
 		}
 	}
 
@@ -317,7 +321,7 @@ func checkRelationV3(ctx context.Context, c *dsc.Client, msg *structpb.Value) *C
 			Outcome:  false,
 			Duration: 0,
 			Err:      ErrSkippedDirectoryAssertion,
-			Str:      "SKIPPED",
+			Str:      skipped,
 		}
 	}
 
@@ -347,7 +351,7 @@ func checkDecisionV2(ctx context.Context, c *azc.Client, msg *structpb.Value) *C
 			Outcome:  false,
 			Duration: 0,
 			Err:      ErrSkippedAuthorizerAssertion,
-			Str:      "SKIPPED",
+			Str:      skipped,
 		}
 	}
 
@@ -385,7 +389,7 @@ func evaluationV1(ctx context.Context, c *dsc.Client, msg *structpb.Value) *Chec
 			Outcome:  false,
 			Duration: 0,
 			Err:      ErrSkippedDirectoryAssertion,
-			Str:      "SKIPPED",
+			Str:      skipped,
 		}
 	}
 

--- a/topaz/cmd/templates/template.go
+++ b/topaz/cmd/templates/template.go
@@ -91,7 +91,7 @@ func download(src, dir string) (string, error) {
 
 func getBytes(fileURL string) ([]byte, error) {
 	if exists, _ := config.FileExists(fileURL); exists {
-		return os.ReadFile(fileURL) //nolint:gosec // G703
+		return os.ReadFile(fileURL)
 	}
 
 	resp, err := http.Get(fileURL) //nolint:gosec,noctx

--- a/topaz/dockerx/docker.go
+++ b/topaz/dockerx/docker.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	running = "running"
+	status  = "status"
 )
 
 func PolicyRoot() string {
@@ -126,7 +127,7 @@ func (dc *DockerClient) Stop(name string) error {
 	containers, err := dc.cli.ContainerList(dc.ctx, container.ListOptions{
 		Filters: filters.NewArgs(
 			filters.KeyValuePair{
-				Key: "status", Value: running,
+				Key: status, Value: running,
 			},
 			filters.KeyValuePair{
 				Key: "name", Value: name,
@@ -151,7 +152,7 @@ func (dc *DockerClient) IsRunning(name string) (bool, error) {
 	containers, err := dc.cli.ContainerList(dc.ctx, container.ListOptions{
 		Filters: filters.NewArgs(
 			filters.KeyValuePair{
-				Key: "status", Value: running,
+				Key: status, Value: running,
 			},
 			filters.KeyValuePair{
 				Key: "name", Value: name,
@@ -173,7 +174,7 @@ func (dc *DockerClient) GetRunningTopazContainers() ([]container.Summary, error)
 	containers, err := dc.cli.ContainerList(dc.ctx, container.ListOptions{
 		Filters: filters.NewArgs(
 			filters.KeyValuePair{
-				Key: "status", Value: running,
+				Key: status, Value: running,
 			},
 		),
 	})


### PR DESCRIPTION
Update 
* golangci-lint to v2.12.2
* golang to v1.26.3
* fix new linter issues
