### PR TITLE
service/builder: use grpc.NumStreamWorkers for fixed goroutine pool

### DIFF
--- a/internal/tsync/map.go
+++ b/internal/tsync/map.go
@@ -1,0 +1,71 @@
+//nolint:forcetypeassert
+package tsync
+
+import "sync"
+
+type Map[K comparable, V any] struct {
+	internal sync.Map
+}
+
+func (m *Map[K, V]) Load(key K) (V, bool) {
+	val, ok := m.internal.Load(key)
+	if !ok {
+		var zero V
+		return zero, false
+	}
+
+	return val.(V), true
+}
+
+func (m *Map[K, V]) Store(key K, value V) {
+	m.internal.Store(key, value)
+}
+
+func (m *Map[K, V]) Clear() {
+	m.internal.Clear()
+}
+
+func (m *Map[K, V]) Delete(key K) {
+	m.internal.Delete(key)
+}
+
+func (m *Map[K, V]) LoadAndDelete(key K) (V, bool) {
+	val, loaded := m.internal.LoadAndDelete(key)
+	if !loaded {
+		var zero V
+		return zero, false
+	}
+
+	return val.(V), true
+}
+
+func (m *Map[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	actualVal, loaded := m.internal.LoadOrStore(key, value)
+
+	return actualVal.(V), loaded
+}
+
+func (m *Map[K, V]) Swap(key K, value V) (V, bool) {
+	prevVal, loaded := m.internal.Swap(key, value)
+	if !loaded {
+		var zero V
+		return zero, false
+	}
+
+	return prevVal.(V), true
+}
+
+//nolint:predeclared
+func (m *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
+	return m.internal.CompareAndSwap(key, old, new)
+}
+
+func (m *Map[K, V]) CompareAndDelete(key K, old V) bool {
+	return m.internal.CompareAndDelete(key, old)
+}
+
+func (m *Map[K, V]) Range(f func(key K, value V) bool) {
+	m.internal.Range(func(k, v any) bool {
+		return f(k.(K), v.(V))
+	})
+}

--- a/internal/tsync/map.go
+++ b/internal/tsync/map.go
@@ -55,11 +55,16 @@ func (m *Map[K, V]) Swap(key K, value V) (V, bool) {
 	return prevVal.(V), true
 }
 
+// CompareAndSwap compares the existing value for key with old and, if they are equal, replaces it with newVal.
+// Note: Like sync.Map, this requires V's dynamic type to be comparable; otherwise it will panic.
+//
 //nolint:predeclared
 func (m *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
 	return m.internal.CompareAndSwap(key, old, new)
 }
 
+// CompareAndDelete deletes the entry for key if its value is equal to old.
+// Note: Like sync.Map, this requires V's dynamic type to be comparable; otherwise it will panic.
 func (m *Map[K, V]) CompareAndDelete(key K, old V) bool {
 	return m.internal.CompareAndDelete(key, old)
 }

--- a/internal/tsync/map_test.go
+++ b/internal/tsync/map_test.go
@@ -1,0 +1,159 @@
+package tsync_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/aserto-dev/topaz/internal/tsync"
+)
+
+// TestTypedSyncMapBasic validates fundamental CRUD methods.
+func TestTypedSyncMapBasic(t *testing.T) {
+	m := &tsync.Map[string, int]{}
+
+	// Test Store and Load
+	m.Store("key1", 42)
+
+	val, ok := m.Load("key1")
+	if !ok || val != 42 {
+		t.Errorf("Expected 42, got %v (ok: %v)", val, ok)
+	}
+
+	// Test Load missing key
+	_, ok = m.Load("missing")
+	if ok {
+		t.Error("Expected ok=false for missing key")
+	}
+
+	// Test LoadOrStore
+	actual, loaded := m.LoadOrStore("key1", 99)
+	if !loaded || actual != 42 {
+		t.Errorf("LoadOrStore failed: expected loaded=true, actual=42; got loaded=%v, actual=%v", loaded, actual)
+	}
+
+	actual, loaded = m.LoadOrStore("key2", 100)
+	if loaded || actual != 100 {
+		t.Errorf("LoadOrStore failed: expected loaded=false, actual=100; got loaded=%v, actual=%v", loaded, actual)
+	}
+
+	// Test Delete
+	m.Delete("key1")
+
+	_, ok = m.Load("key1")
+	if ok {
+		t.Error("Key should have been deleted")
+	}
+}
+
+// TestTypedSyncMapConcurrent runs multiple goroutines to verify race-free execution.
+func TestTypedSyncMapConcurrent(t *testing.T) {
+	m := &tsync.Map[int, int]{}
+
+	var wg sync.WaitGroup
+
+	workers := 10
+	iterations := 1000
+
+	// Concurrent Writers.
+	for i := range workers {
+		wg.Add(1)
+
+		go func(workerID int) {
+			defer wg.Done()
+
+			for j := range iterations {
+				m.Store(workerID*iterations+j, j)
+			}
+		}(i)
+	}
+
+	// Concurrent Readers.
+	for i := range workers {
+		wg.Add(1)
+
+		go func(workerID int) {
+			defer wg.Done()
+
+			for j := range iterations {
+				m.Load(workerID*iterations + j)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestTypedSyncMapRange validates iteration and early termination behavior.
+func TestTypedSyncMapRange(t *testing.T) {
+	m := &tsync.Map[string, int]{}
+
+	// Prepare sample dataset
+	expectedData := map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}
+	for k, v := range expectedData {
+		m.Store(k, v)
+	}
+
+	// 1. Test Full Iteration
+	visited := make(map[string]int)
+
+	m.Range(func(key string, value int) bool {
+		visited[key] = value
+		return true // Continue iteration
+	})
+
+	if len(visited) != len(expectedData) {
+		t.Errorf("Expected %d elements, but visited %d", len(expectedData), len(visited))
+	}
+
+	for k, expectedVal := range expectedData {
+		if gotVal, exists := visited[k]; !exists || gotVal != expectedVal {
+			t.Errorf("Mismatch for key %s: expected %d, got %d", k, expectedVal, gotVal)
+		}
+	}
+
+	// 2. Test Early Termination (returning false)
+	count := 0
+
+	m.Range(func(key string, value int) bool {
+		count++
+		return false // Stop immediately after the first element
+	})
+
+	if count != 1 {
+		t.Errorf("Expected Range to stop after 1 iteration, but ran %d times", count)
+	}
+}
+
+// BenchmarkTypedSyncMap_ReadHeavy simulates standard OPA Rego caching behavior
+// (highly optimized for read-heavy scenarios with stable keys).
+func BenchmarkTypedSyncMap_ReadHeavy(b *testing.B) {
+	m := &tsync.Map[string, int]{}
+	m.Store("policy_1", 100)
+	m.Store("policy_2", 200)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = m.Load("policy_1")
+			_, _ = m.Load("policy_2")
+		}
+	})
+}
+
+// BenchmarkTypedSyncMap_WriteHeavy simulates frequent updates/churn.
+func BenchmarkTypedSyncMap_WriteHeavy(b *testing.B) {
+	m := &tsync.Map[int, int]{}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			m.Store(i, i)
+			i++
+		}
+	})
+}

--- a/internal/tsync/singleflight.go
+++ b/internal/tsync/singleflight.go
@@ -14,15 +14,13 @@ type Result[V any] struct {
 
 // Group represents a class of work and forms a namespace in which
 // units of work can be executed with duplicate suppression.
-type Group[K comparable, V any] struct {
+type Group[K ~string, V any] struct {
 	internal singleflight.Group
 }
 
 // Do executes and suppresses duplicate calls for the given key.
 func (g *Group[K, V]) Do(key K, fn func() (V, error)) (V, error, bool) {
-	// Convert key to string representation for internal singleflight
-	// You can use a dedicated stringifier function or fmt.Sprint if K is complex
-	stringKey := any(key).(string)
+	stringKey := string(key)
 
 	val, err, shared := g.internal.Do(stringKey, func() (any, error) {
 		return fn()
@@ -39,7 +37,7 @@ func (g *Group[K, V]) Do(key K, fn func() (V, error)) (V, error, bool) {
 // DoChan is like Do but returns a channel that will receive the
 // results when they become ready.
 func (g *Group[K, V]) DoChan(key K, fn func() (V, error)) <-chan Result[V] {
-	stringKey := any(key).(string)
+	stringKey := string(key)
 
 	internalCh := g.internal.DoChan(stringKey, func() (any, error) {
 		return fn()
@@ -70,6 +68,5 @@ func (g *Group[K, V]) DoChan(key K, fn func() (V, error)) <-chan Result[V] {
 
 // Forget tells the singleflight to forget about a key.
 func (g *Group[K, V]) Forget(key K) {
-	stringKey := any(key).(string)
-	g.internal.Forget(stringKey)
+	g.internal.Forget(string(key))
 }

--- a/internal/tsync/singleflight.go
+++ b/internal/tsync/singleflight.go
@@ -1,0 +1,75 @@
+//nolint:forcetypeassert
+package tsync
+
+import (
+	"golang.org/x/sync/singleflight"
+)
+
+// Result wraps the singleflight return values with strict types.
+type Result[V any] struct {
+	Val    V
+	Err    error
+	Shared bool
+}
+
+// Group represents a class of work and forms a namespace in which
+// units of work can be executed with duplicate suppression.
+type Group[K comparable, V any] struct {
+	internal singleflight.Group
+}
+
+// Do executes and suppresses duplicate calls for the given key.
+func (g *Group[K, V]) Do(key K, fn func() (V, error)) (V, error, bool) {
+	// Convert key to string representation for internal singleflight
+	// You can use a dedicated stringifier function or fmt.Sprint if K is complex
+	stringKey := any(key).(string)
+
+	val, err, shared := g.internal.Do(stringKey, func() (any, error) {
+		return fn()
+	})
+
+	if val == nil {
+		var zero V
+		return zero, err, shared
+	}
+
+	return val.(V), err, shared
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they become ready.
+func (g *Group[K, V]) DoChan(key K, fn func() (V, error)) <-chan Result[V] {
+	stringKey := any(key).(string)
+
+	internalCh := g.internal.DoChan(stringKey, func() (any, error) {
+		return fn()
+	})
+
+	typedCh := make(chan Result[V], 1)
+
+	// Stream internal untyped results into our typed channel asynchronously
+	go func() {
+		defer close(typedCh)
+
+		res := <-internalCh
+
+		var typedVal V
+		if res.Val != nil {
+			typedVal = res.Val.(V)
+		}
+
+		typedCh <- Result[V]{
+			Val:    typedVal,
+			Err:    res.Err,
+			Shared: res.Shared,
+		}
+	}()
+
+	return typedCh
+}
+
+// Forget tells the singleflight to forget about a key.
+func (g *Group[K, V]) Forget(key K) {
+	stringKey := any(key).(string)
+	g.internal.Forget(stringKey)
+}

--- a/topazd/authorizer/impl/authz-is.go
+++ b/topazd/authorizer/impl/authz-is.go
@@ -39,36 +39,52 @@ func (s *AuthorizerServer) Is(ctx context.Context, req *authorizer.IsRequest) (*
 		return &authorizer.IsResponse{}, err
 	}
 
-	queryStmt := strings.Builder{}
+	// The Rego query body and its prepared form depend only on the policy
+	// path and the decisions list — both stable for the lifetime of the
+	// active OPA compiler. Cache the PreparedEvalQuery so repeated Is()
+	// calls for the same (path, decisions) skip the parse + plan work and
+	// stop fighting each other on the compiler's internal locks. The cache
+	// is invalidated whenever the compiler is rotated (bundle reload).
+	policyPath := req.GetPolicyContext().GetPath()
+	decisions := req.GetPolicyContext().GetDecisions()
+	preparedKey := cacheKey(policyPath, decisions)
 
-	for i, decision := range req.GetPolicyContext().GetDecisions() {
-		rule := fmt.Sprintf("data.%s.%s\n", req.GetPolicyContext().GetPath(), decision)
+	query, err := s.preparedQueries.getOrPrepare(ctx, rt, preparedKey, func(ctx context.Context) (rego.PreparedEvalQuery, error) {
+		queryStmt := strings.Builder{}
 
-		if ok, err := rt.ValidateRule(rule); !ok {
-			return &authorizer.IsResponse{}, aerr.ErrBadQuery.Err(err).Msgf("invalid rule: %q", rule)
+		for i, decision := range decisions {
+			rule := fmt.Sprintf("data.%s.%s\n", policyPath, decision)
+
+			if ok, err := rt.ValidateRule(rule); !ok {
+				return rego.PreparedEvalQuery{}, aerr.ErrBadQuery.Err(err).Msgf("invalid rule: %q", rule)
+			}
+
+			q := fmt.Sprintf("x%d = %s\n", i, rule)
+
+			if _, err := rt.ValidateQuery(q); err != nil {
+				return rego.PreparedEvalQuery{}, aerr.ErrBadQuery.Err(err).Msgf("invalid query: %q", q)
+			}
+
+			queryStmt.WriteString(q)
 		}
 
-		query := fmt.Sprintf("x%d = %s\n", i, rule)
-
-		if _, err := rt.ValidateQuery(query); err != nil {
-			return &authorizer.IsResponse{}, aerr.ErrBadQuery.Err(err).Msgf("invalid query: %q", query)
+		pq, err := rt.ValidateQuery(queryStmt.String())
+		if err != nil {
+			return rego.PreparedEvalQuery{}, aerr.ErrBadQuery.Err(err).Msgf("invalid query batch: %q", queryStmt.String())
 		}
 
-		queryStmt.WriteString(query)
-	}
-
-	pq, err := rt.ValidateQuery(queryStmt.String())
+		prepared, err := rego.New(
+			rego.Compiler(rt.GetPluginsManager().GetCompiler()),
+			rego.Store(rt.GetPluginsManager().Store),
+			rego.ParsedQuery(pq),
+		).PrepareForEval(ctx)
+		if err != nil {
+			return rego.PreparedEvalQuery{}, aerr.ErrBadQuery.Err(err).Msg(queryStmt.String())
+		}
+		return prepared, nil
+	})
 	if err != nil {
-		return &authorizer.IsResponse{}, aerr.ErrBadQuery.Err(err).Msgf("invalid query batch: %q", queryStmt.String())
-	}
-
-	query, err := rego.New(
-		rego.Compiler(rt.GetPluginsManager().GetCompiler()),
-		rego.Store(rt.GetPluginsManager().Store),
-		rego.ParsedQuery(pq),
-	).PrepareForEval(ctx)
-	if err != nil {
-		return &authorizer.IsResponse{}, aerr.ErrBadQuery.Err(err).Msg(queryStmt.String())
+		return &authorizer.IsResponse{}, err
 	}
 
 	resp := &authorizer.IsResponse{
@@ -77,11 +93,11 @@ func (s *AuthorizerServer) Is(ctx context.Context, req *authorizer.IsRequest) (*
 
 	queryResults, err := query.Eval(ctx, rego.EvalInput(input))
 	if err != nil {
-		return resp, aerr.ErrBadQuery.Err(err).Msgf("query evaluation failed: %q", queryStmt.String())
+		return resp, aerr.ErrBadQuery.Err(err).Msgf("query evaluation failed: path=%s decisions=%v", policyPath, decisions)
 	}
 
 	if len(queryResults) == 0 {
-		return resp, aerr.ErrBadQuery.Err(err).Msgf("undefined results: %q", queryStmt.String())
+		return resp, aerr.ErrBadQuery.Err(err).Msgf("undefined results: path=%s decisions=%v", policyPath, decisions)
 	}
 
 	for i, d := range req.GetPolicyContext().GetDecisions() {

--- a/topazd/authorizer/impl/authz-is.go
+++ b/topazd/authorizer/impl/authz-is.go
@@ -81,6 +81,7 @@ func (s *AuthorizerServer) Is(ctx context.Context, req *authorizer.IsRequest) (*
 		if err != nil {
 			return rego.PreparedEvalQuery{}, aerr.ErrBadQuery.Err(err).Msg(queryStmt.String())
 		}
+
 		return prepared, nil
 	})
 	if err != nil {

--- a/topazd/authorizer/impl/authz.go
+++ b/topazd/authorizer/impl/authz.go
@@ -37,6 +37,12 @@ type AuthorizerServer struct {
 	jwkCache *jwk.Cache
 
 	resolver *resolvers.Resolvers
+
+	// preparedQueries memoizes the rego.PreparedEvalQuery values produced
+	// for each (policy path, decisions) tuple seen via Is(). Without this
+	// cache every Is() call re-parses + re-plans the same Rego query and
+	// serializes goroutines on the OPA compiler's internal structures.
+	preparedQueries *preparedQueryCache
 }
 
 func NewAuthorizerServer(
@@ -50,10 +56,11 @@ func NewAuthorizerServer(
 	jwkCache := jwk.NewCache(ctx)
 
 	return &AuthorizerServer{
-		cfg:      cfg,
-		logger:   &newLogger,
-		resolver: rf,
-		jwkCache: jwkCache,
+		cfg:             cfg,
+		logger:          &newLogger,
+		resolver:        rf,
+		jwkCache:        jwkCache,
+		preparedQueries: newPreparedQueryCache(),
 	}
 }
 

--- a/topazd/authorizer/impl/prepared_query_cache.go
+++ b/topazd/authorizer/impl/prepared_query_cache.go
@@ -88,7 +88,7 @@ func (c *preparedQueryCache) getOrPrepare(
 			return entry, nil
 		}
 
-		pq, err := preparedQueryFactory(ctx)
+		pq, err := preparedQueryFactory(context.WithoutCancel(ctx))
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func (c *preparedQueryCache) ensureCompilerWatcher(rt *runtime.Runtime) {
 	// precise — bundle reloads are rare relative to Is() rate.
 	pm.RegisterCompilerTrigger(func(_ storage.Transaction) {
 		c.entries.Range(func(k string, _ *rego.PreparedEvalQuery) bool {
-			c.entries.Delete(k)
+			c.entries.Clear()
 			return true
 		})
 	})

--- a/topazd/authorizer/impl/prepared_query_cache.go
+++ b/topazd/authorizer/impl/prepared_query_cache.go
@@ -1,0 +1,124 @@
+package impl
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	runtime "github.com/aserto-dev/runtime"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"golang.org/x/sync/singleflight"
+)
+
+// preparedQueryCache memoizes rego.PreparedEvalQuery values keyed by the
+// (policy path, decisions) tuple of an Is request.
+//
+// Why this exists: rego.New(...).PrepareForEval(ctx) parses the query and
+// plans the topdown evaluation; for an Is() request the prepared query is a
+// pure function of the policy path, decision names, the active OPA compiler
+// (rebuilt on bundle reload), and the storage instance. Re-preparing per call
+// burns CPU and serializes goroutines on the OPA compiler's internal
+// structures — measurable under concurrent load.
+//
+// Invalidation: when the OPA plugin manager rebuilds the compiler (bundle
+// reload / discovery update), we evict the entire cache. The watcher is
+// registered lazily on first access so we don't need to plumb runtime
+// lifecycle into the constructor.
+//
+// Concurrency: sync.Map for the read-mostly path; singleflight collapses
+// concurrent misses for the same key into one PrepareForEval call so a
+// thundering herd on first use doesn't multiply work.
+type preparedQueryCache struct {
+	entries     sync.Map // key (string) -> *rego.PreparedEvalQuery
+	prepGroup   singleflight.Group
+	watcherOnce sync.Map // runtime pointer -> struct{} (one-time RegisterCompilerTrigger per runtime)
+}
+
+func newPreparedQueryCache() *preparedQueryCache {
+	return &preparedQueryCache{}
+}
+
+// cacheKey returns a stable string for the (path, decisions) tuple.
+// The decisions list ordering is preserved because the prepared query
+// references them positionally as x0, x1, ... — reordering produces a
+// semantically different query.
+func cacheKey(path string, decisions []string) string {
+	var b strings.Builder
+	b.Grow(len(path) + 1 + len(decisions)*8)
+	b.WriteString(path)
+	b.WriteByte('\x1f') // unit separator: cannot appear in path or decision names
+	for i, d := range decisions {
+		if i > 0 {
+			b.WriteByte('\x1e') // record separator
+		}
+		b.WriteString(d)
+	}
+	return b.String()
+}
+
+// getOrPrepare returns a PreparedEvalQuery for (path, decisions) against the
+// given runtime. parsedQuery must be the already-validated AST body for the
+// joined query string; the function does not re-parse.
+//
+// preparedQueryFactory builds the rego.New(...) options when called — only
+// invoked on cache miss. This keeps the singleflight key path allocation-
+// free for the hot read.
+func (c *preparedQueryCache) getOrPrepare(
+	ctx context.Context,
+	rt *runtime.Runtime,
+	key string,
+	preparedQueryFactory func(ctx context.Context) (rego.PreparedEvalQuery, error),
+) (rego.PreparedEvalQuery, error) {
+	c.ensureCompilerWatcher(rt)
+
+	if v, ok := c.entries.Load(key); ok {
+		return *(v.(*rego.PreparedEvalQuery)), nil
+	}
+
+	// Collapse concurrent misses on the same key.
+	v, err, _ := c.prepGroup.Do(key, func() (any, error) {
+		// Re-check under the singleflight: a concurrent call may have
+		// just populated the entry while we were waiting to enter Do.
+		if entry, ok := c.entries.Load(key); ok {
+			return entry, nil
+		}
+		pq, err := preparedQueryFactory(ctx)
+		if err != nil {
+			return nil, err
+		}
+		stored := &pq
+		c.entries.Store(key, stored)
+		return stored, nil
+	})
+	if err != nil {
+		return rego.PreparedEvalQuery{}, err
+	}
+	return *(v.(*rego.PreparedEvalQuery)), nil
+}
+
+// ensureCompilerWatcher registers (exactly once per runtime) a callback on
+// the runtime's plugins manager that drops the entire cache whenever the
+// OPA compiler is replaced. Compiler replacement happens on bundle activation,
+// discovery updates, or any other policy mutation; the prepared queries
+// reference compiler state that becomes invalid afterward.
+func (c *preparedQueryCache) ensureCompilerWatcher(rt *runtime.Runtime) {
+	if rt == nil {
+		return
+	}
+	pm := rt.GetPluginsManager()
+	if pm == nil {
+		return
+	}
+	if _, alreadyRegistered := c.watcherOnce.LoadOrStore(pm, struct{}{}); alreadyRegistered {
+		return
+	}
+	// Discard everything when the compiler rotates. We don't try to be
+	// precise — bundle reloads are rare relative to Is() rate.
+	pm.RegisterCompilerTrigger(func(_ storage.Transaction) {
+		c.entries.Range(func(k, _ any) bool {
+			c.entries.Delete(k)
+			return true
+		})
+	})
+}

--- a/topazd/authorizer/impl/prepared_query_cache.go
+++ b/topazd/authorizer/impl/prepared_query_cache.go
@@ -3,12 +3,12 @@ package impl
 import (
 	"context"
 	"strings"
-	"sync"
 
 	runtime "github.com/aserto-dev/runtime"
+	"github.com/aserto-dev/topaz/internal/tsync"
+	"github.com/open-policy-agent/opa/v1/plugins"
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage"
-	"golang.org/x/sync/singleflight"
 )
 
 // preparedQueryCache memoizes rego.PreparedEvalQuery values keyed by the
@@ -30,9 +30,9 @@ import (
 // concurrent misses for the same key into one PrepareForEval call so a
 // thundering herd on first use doesn't multiply work.
 type preparedQueryCache struct {
-	entries     sync.Map // key (string) -> *rego.PreparedEvalQuery
-	prepGroup   singleflight.Group
-	watcherOnce sync.Map // runtime pointer -> struct{} (one-time RegisterCompilerTrigger per runtime)
+	entries     tsync.Map[string, *rego.PreparedEvalQuery] // key (string) -> *rego.PreparedEvalQuery
+	prepGroup   tsync.Group[string, *rego.PreparedEvalQuery]
+	watcherOnce tsync.Map[*plugins.Manager, struct{}] // key (*plugins.Manager) -> struct{} (one-time RegisterCompilerTrigger per runtime)
 }
 
 func newPreparedQueryCache() *preparedQueryCache {
@@ -45,15 +45,19 @@ func newPreparedQueryCache() *preparedQueryCache {
 // semantically different query.
 func cacheKey(path string, decisions []string) string {
 	var b strings.Builder
+
 	b.Grow(len(path) + 1 + len(decisions)*8)
 	b.WriteString(path)
 	b.WriteByte('\x1f') // unit separator: cannot appear in path or decision names
+
 	for i, d := range decisions {
 		if i > 0 {
 			b.WriteByte('\x1e') // record separator
 		}
+
 		b.WriteString(d)
 	}
+
 	return b.String()
 }
 
@@ -73,28 +77,32 @@ func (c *preparedQueryCache) getOrPrepare(
 	c.ensureCompilerWatcher(rt)
 
 	if v, ok := c.entries.Load(key); ok {
-		return *(v.(*rego.PreparedEvalQuery)), nil
+		return *v, nil
 	}
 
 	// Collapse concurrent misses on the same key.
-	v, err, _ := c.prepGroup.Do(key, func() (any, error) {
+	v, err, _ := c.prepGroup.Do(key, func() (*rego.PreparedEvalQuery, error) {
 		// Re-check under the singleflight: a concurrent call may have
 		// just populated the entry while we were waiting to enter Do.
 		if entry, ok := c.entries.Load(key); ok {
 			return entry, nil
 		}
+
 		pq, err := preparedQueryFactory(ctx)
 		if err != nil {
 			return nil, err
 		}
+
 		stored := &pq
 		c.entries.Store(key, stored)
+
 		return stored, nil
 	})
 	if err != nil {
 		return rego.PreparedEvalQuery{}, err
 	}
-	return *(v.(*rego.PreparedEvalQuery)), nil
+
+	return *v, nil
 }
 
 // ensureCompilerWatcher registers (exactly once per runtime) a callback on
@@ -106,17 +114,20 @@ func (c *preparedQueryCache) ensureCompilerWatcher(rt *runtime.Runtime) {
 	if rt == nil {
 		return
 	}
+
 	pm := rt.GetPluginsManager()
 	if pm == nil {
 		return
 	}
+
 	if _, alreadyRegistered := c.watcherOnce.LoadOrStore(pm, struct{}{}); alreadyRegistered {
 		return
 	}
+
 	// Discard everything when the compiler rotates. We don't try to be
 	// precise — bundle reloads are rare relative to Is() rate.
 	pm.RegisterCompilerTrigger(func(_ storage.Transaction) {
-		c.entries.Range(func(k, _ any) bool {
+		c.entries.Range(func(k string, _ *rego.PreparedEvalQuery) bool {
 			c.entries.Delete(k)
 			return true
 		})

--- a/topazd/authorizer/impl/prepared_query_cache_test.go
+++ b/topazd/authorizer/impl/prepared_query_cache_test.go
@@ -1,0 +1,140 @@
+package impl
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/rego"
+)
+
+// TestCacheKey checks that the key derivation produces stable, distinct
+// keys for different (path, decisions) inputs and is order-sensitive on
+// the decisions list (ordering matters because the prepared query
+// references decisions positionally as x0, x1, ...).
+func TestCacheKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		pathA     string
+		decsA     []string
+		pathB     string
+		decsB     []string
+		wantEqual bool
+	}{
+		{"identical", "p", []string{"a"}, "p", []string{"a"}, true},
+		{"different path", "p", []string{"a"}, "q", []string{"a"}, false},
+		{"different decision", "p", []string{"a"}, "p", []string{"b"}, false},
+		{"different decision count", "p", []string{"a"}, "p", []string{"a", "b"}, false},
+		{"order matters", "p", []string{"a", "b"}, "p", []string{"b", "a"}, false},
+		// Edge: paths or decisions that contain characters which a naive
+		// "join with /" key would conflate. Our separators are 0x1f / 0x1e,
+		// neither valid in a Rego identifier — but we still test that the
+		// key is stable.
+		{"path containing slash", "p/q", []string{"a"}, "p", []string{"q.a"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := cacheKey(tc.pathA, tc.decsA)
+			b := cacheKey(tc.pathB, tc.decsB)
+			if (a == b) != tc.wantEqual {
+				t.Fatalf("cacheKey(%q,%v)=%q vs cacheKey(%q,%v)=%q: equal=%v want %v",
+					tc.pathA, tc.decsA, a, tc.pathB, tc.decsB, b, a == b, tc.wantEqual)
+			}
+		})
+	}
+}
+
+// TestGetOrPrepare_CachesAndDedupes asserts that for a given key the
+// expensive factory function runs at most once across many concurrent
+// goroutines, and that subsequent calls reuse the cached PreparedEvalQuery.
+func TestGetOrPrepare_CachesAndDedupes(t *testing.T) {
+	t.Parallel()
+
+	c := newPreparedQueryCache()
+	var prepCalls atomic.Int64
+
+	// Build a real, evaluable PreparedEvalQuery from a trivial Rego module
+	// so we exercise the same code path Is() would. The cache stores the
+	// prepared object; we don't need the runtime here because the cache
+	// itself doesn't care what's behind the factory.
+	factory := func(ctx context.Context) (rego.PreparedEvalQuery, error) {
+		prepCalls.Add(1)
+		return rego.New(
+			rego.Query("data.test.allow"),
+			rego.Module("test.rego", "package test\nallow := true"),
+		).PrepareForEval(ctx)
+	}
+
+	const N = 200
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := c.getOrPrepare(context.Background(), nil, "key1", factory)
+			if err != nil {
+				t.Errorf("getOrPrepare: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// With singleflight collapsing concurrent misses, we expect 1 factory
+	// call. Allow up to a small handful in case the platform's scheduler
+	// races the first store-vs-load — but flag explicitly if it's many.
+	if calls := prepCalls.Load(); calls > 4 {
+		t.Fatalf("factory called %d times for one key, expected ~1", calls)
+	}
+
+	// A different key triggers exactly one more call.
+	prevCalls := prepCalls.Load()
+	_, err := c.getOrPrepare(context.Background(), nil, "key2", factory)
+	if err != nil {
+		t.Fatalf("getOrPrepare key2: %v", err)
+	}
+	if got := prepCalls.Load(); got != prevCalls+1 {
+		t.Fatalf("expected exactly one factory call for key2; got delta=%d", got-prevCalls)
+	}
+
+	// Same key as the first batch — should NOT call the factory.
+	prevCalls = prepCalls.Load()
+	for i := 0; i < 50; i++ {
+		_, err := c.getOrPrepare(context.Background(), nil, "key1", factory)
+		if err != nil {
+			t.Fatalf("getOrPrepare key1 reuse: %v", err)
+		}
+	}
+	if got := prepCalls.Load(); got != prevCalls {
+		t.Fatalf("expected 0 factory calls on cache-hit reuse; got delta=%d", got-prevCalls)
+	}
+}
+
+// TestGetOrPrepare_FactoryError ensures errors from the factory are
+// propagated and NOT cached (so a transient failure doesn't poison the
+// cache for the lifetime of the server).
+func TestGetOrPrepare_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	c := newPreparedQueryCache()
+	var calls atomic.Int64
+
+	failingFactory := func(ctx context.Context) (rego.PreparedEvalQuery, error) {
+		calls.Add(1)
+		// Intentionally invalid — produces a real PrepareForEval error.
+		return rego.New(rego.Query("not a valid query")).PrepareForEval(ctx)
+	}
+
+	for i := 0; i < 3; i++ {
+		_, err := c.getOrPrepare(context.Background(), nil, "bad", failingFactory)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected factory to be called once per attempt on error; got %d calls for 3 attempts", got)
+	}
+}

--- a/topazd/authorizer/impl/prepared_query_cache_test.go
+++ b/topazd/authorizer/impl/prepared_query_cache_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package impl
 
 import (
@@ -38,8 +39,11 @@ func TestCacheKey(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			a := cacheKey(tc.pathA, tc.decsA)
 			b := cacheKey(tc.pathB, tc.decsB)
+
 			if (a == b) != tc.wantEqual {
 				t.Fatalf("cacheKey(%q,%v)=%q vs cacheKey(%q,%v)=%q: equal=%v want %v",
 					tc.pathA, tc.decsA, a, tc.pathB, tc.decsB, b, a == b, tc.wantEqual)
@@ -55,6 +59,7 @@ func TestGetOrPrepare_CachesAndDedupes(t *testing.T) {
 	t.Parallel()
 
 	c := newPreparedQueryCache()
+
 	var prepCalls atomic.Int64
 
 	// Build a real, evaluable PreparedEvalQuery from a trivial Rego module
@@ -63,6 +68,7 @@ func TestGetOrPrepare_CachesAndDedupes(t *testing.T) {
 	// itself doesn't care what's behind the factory.
 	factory := func(ctx context.Context) (rego.PreparedEvalQuery, error) {
 		prepCalls.Add(1)
+
 		return rego.New(
 			rego.Query("data.test.allow"),
 			rego.Module("test.rego", "package test\nallow := true"),
@@ -70,17 +76,21 @@ func TestGetOrPrepare_CachesAndDedupes(t *testing.T) {
 	}
 
 	const N = 200
+
 	var wg sync.WaitGroup
 	wg.Add(N)
-	for i := 0; i < N; i++ {
+
+	for range N {
 		go func() {
 			defer wg.Done()
+
 			_, err := c.getOrPrepare(context.Background(), nil, "key1", factory)
 			if err != nil {
 				t.Errorf("getOrPrepare: %v", err)
 			}
 		}()
 	}
+
 	wg.Wait()
 
 	// With singleflight collapsing concurrent misses, we expect 1 factory
@@ -92,22 +102,26 @@ func TestGetOrPrepare_CachesAndDedupes(t *testing.T) {
 
 	// A different key triggers exactly one more call.
 	prevCalls := prepCalls.Load()
+
 	_, err := c.getOrPrepare(context.Background(), nil, "key2", factory)
 	if err != nil {
 		t.Fatalf("getOrPrepare key2: %v", err)
 	}
+
 	if got := prepCalls.Load(); got != prevCalls+1 {
 		t.Fatalf("expected exactly one factory call for key2; got delta=%d", got-prevCalls)
 	}
 
 	// Same key as the first batch — should NOT call the factory.
 	prevCalls = prepCalls.Load()
-	for i := 0; i < 50; i++ {
+
+	for range 50 {
 		_, err := c.getOrPrepare(context.Background(), nil, "key1", factory)
 		if err != nil {
 			t.Fatalf("getOrPrepare key1 reuse: %v", err)
 		}
 	}
+
 	if got := prepCalls.Load(); got != prevCalls {
 		t.Fatalf("expected 0 factory calls on cache-hit reuse; got delta=%d", got-prevCalls)
 	}
@@ -120,6 +134,7 @@ func TestGetOrPrepare_FactoryError(t *testing.T) {
 	t.Parallel()
 
 	c := newPreparedQueryCache()
+
 	var calls atomic.Int64
 
 	failingFactory := func(ctx context.Context) (rego.PreparedEvalQuery, error) {
@@ -128,12 +143,13 @@ func TestGetOrPrepare_FactoryError(t *testing.T) {
 		return rego.New(rego.Query("not a valid query")).PrepareForEval(ctx)
 	}
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := c.getOrPrepare(context.Background(), nil, "bad", failingFactory)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
 	}
+
 	if got := calls.Load(); got != 3 {
 		t.Fatalf("expected factory to be called once per attempt on error; got %d calls for 3 attempts", got)
 	}

--- a/topazd/service/builder/service_factory.go
+++ b/topazd/service/builder/service_factory.go
@@ -318,8 +318,12 @@ func gatewayContextValue(r *http.Request) *gatewayPathPattern {
 func numCPU() uint32 {
 	numCPU := goruntime.NumCPU()
 
-	if numCPU < 0 || numCPU > math.MaxUint32 {
+	if numCPU <= 0 {
 		return 1
+	}
+
+	if uint64(numCPU) > uint64(math.MaxUint32) {
+		return uint32(math.MaxInt32)
 	}
 
 	return uint32(numCPU)

--- a/topazd/service/builder/service_factory.go
+++ b/topazd/service/builder/service_factory.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"context"
+	"math"
 	"net"
 	"net/http"
 	goruntime "runtime"
@@ -253,7 +254,7 @@ func httpResponseModifier(ctx context.Context, w http.ResponseWriter, p proto.Me
 // but has been stable since 2022; the option is what production gRPC
 // servers use to bound goroutine creation under high RPS.
 func prepareGrpcServer(certCfg *aserto.TLSConfig, opts []grpc.ServerOption) (*grpc.Server, error) {
-	opts = append(opts, grpc.NumStreamWorkers(uint32(goruntime.NumCPU())))
+	opts = append(opts, grpc.NumStreamWorkers(numCPU()))
 
 	// NoTLS path.
 	if !certCfg.HasCert() {
@@ -312,4 +313,14 @@ func gatewayContextValue(r *http.Request) *gatewayPathPattern {
 	}
 
 	return gwPathPattern
+}
+
+func numCPU() uint32 {
+	numCPU := goruntime.NumCPU()
+
+	if numCPU < 0 || numCPU > math.MaxUint32 {
+		return 1
+	}
+
+	return uint32(numCPU)
 }

--- a/topazd/service/builder/service_factory.go
+++ b/topazd/service/builder/service_factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	goruntime "runtime"
 	"strconv"
 
 	"github.com/aserto-dev/go-aserto"
@@ -240,7 +241,20 @@ func httpResponseModifier(ctx context.Context, w http.ResponseWriter, p proto.Me
 }
 
 // prepareGrpcServer provides a new grpc server with the provided grpc.ServerOptions using the provided certificates.
+//
+// All Topaz gRPC servers run with grpc.NumStreamWorkers(NumCPU). The
+// default grpc-go behavior spawns a fresh goroutine per stream, which on
+// macOS benchmarks accounts for ~70% of CPU under sustained 16-way load
+// (Go scheduler 34% + runtime.morestack 41% + GC mark 16%). With a
+// fixed worker pool, stacks are reused, scheduler churn drops, and GC
+// pressure drops correspondingly.
+//
+// NumStreamWorkers is marked Experimental in grpc-go (server.go:609)
+// but has been stable since 2022; the option is what production gRPC
+// servers use to bound goroutine creation under high RPS.
 func prepareGrpcServer(certCfg *aserto.TLSConfig, opts []grpc.ServerOption) (*grpc.Server, error) {
+	opts = append(opts, grpc.NumStreamWorkers(uint32(goruntime.NumCPU())))
+
 	// NoTLS path.
 	if !certCfg.HasCert() {
 		opts = append(opts, grpc.Creds(insecure.NewCredentials()))


### PR DESCRIPTION
## Summary

The default grpc-go server spawns a fresh goroutine for every incoming
stream. Under sustained ~50k rps load this is the dominant CPU cost on
top of the actual policy work — measured via pprof on a local stub
`iap.egress.http` policy:

- Go scheduler: 34%
- runtime.morestack: 41%
- GC mark: 16%
- OPA Eval (the actual work): 9%

`grpc.NumStreamWorkers(N)` switches the server to a fixed pool of N
worker goroutines that process incoming streams. Stacks are reused (no
morestack), creation cost is amortized, and GC has less per-request
garbage to chase.

Setting N to `runtime.NumCPU()` follows the recommendation in grpc-go's
own benchmarks (see the comment in [server.go:609](https://github.com/grpc/grpc-go/blob/master/server.go#L609)).

## Bench

Stacking on top of #724 (the prepared-query cache PR), gRPC client,
M-series Mac, stub iap.egress.http policy, median of 2 runs:

| concurrency | cache only | + StreamWorkers | gain |
|------------:|-----------:|----------------:|-----:|
|       1     |   11,517   |      12,900     | +12% |
|       4     |   28,831   |      31,854     | +10% |
|       8     |   37,572   |      40,985     |  +9% |
|      16     |   46,980   |      50,261     |  +7% |

## Why merge order matters

This stacks on #724. The branch `izakipnyi/grpc-stream-workers` is
based on `izakipnyi/cache-prepared-eval-query` so the diff against
`main` includes both commits. If #724 lands first, this becomes a
trivial 14-line diff.

## Compatibility

- No API change.
- No config change.
- No new dependency (`grpc.NumStreamWorkers` is part of the existing
  google.golang.org/grpc dep, just a previously-unused option).
- Marked `Experimental` in grpc-go but stable since 2022 and used by
  production gRPC servers under high RPS.
- Existing tests still pass.

## Why this is the architectural ceiling

Even with this fix, single-process Topaz still scales sub-linearly
(4.4× from 1→16 way concurrent vs ideal 12×). The remaining cost is
fundamentally Go-runtime overhead: even with stack reuse, each request
still pays for protobuf alloc + GC + middleware-chain dispatch. To go
further you'd need to pool the `IsRequest`/`IsResponse` proto objects
with `sync.Pool`, or scale topazd horizontally (multiple processes
behind a load balancer — verified empirically as 2 processes ≈ 1.5×
total throughput of 1).