### PR TITLE
docs: fix incorrect build output path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ $ go install github.com/aserto-dev/topaz/topaz@latest
  2. Build and run the executable
 
 ```console
-$ make build && ./dist/build_linux_amd64/topaz
+$ make build
+$ ./dist/topaz_<os>_<arch>/topaz
 ```
+
+`make build` compiles for your host platform by default. To target a different platform, set `GOOS`/`GOARCH`, e.g. `GOOS=linux GOARCH=amd64 make build`. The exact output path is listed in the `building binary=...` build log line, or in `dist/artifacts.json`.
 
 ### Running with Docker
 


### PR DESCRIPTION
## Summary
- Building from source on macOS following the README's `make build && ./dist/build_linux_amd64/topaz` command fails with that path doesn't exist. `make build` runs `goreleaser build --single-target`, which outputs to `dist/<binary>_<os>_<arch>/` (e.g. `dist/topaz_darwin_arm64_v8.0/topaz` on Apple Silicon), not `dist/build_linux_amd64/`.
- Updated the README to show the correct output path pattern and note that `GOOS`/`GOARCH` env vars control the target platform (e.g. `GOOS=linux GOARCH=amd64 make build`), with a pointer to `dist/artifacts.json` for the exact path.
