### PR TITLE
fix windows topaz CLI templates install bug

### DIFF
--- a/topaz/cmd/templates/template.go
+++ b/topaz/cmd/templates/template.go
@@ -61,7 +61,7 @@ type template struct {
 
 func (t *template) AbsURL(relative string) string {
 	abs := *t.base
-	abs.Path = filepath.Join(abs.Path, relative)
+	abs.Path = path.Join(abs.Path, relative)
 
 	return abs.String()
 }
@@ -161,7 +161,7 @@ func getTemplateRef(name string, templatesURL *url.URL) (*tmplRef, error) {
 
 		if parsed.Scheme == "" {
 			absURL := *templatesURL
-			absURL.Path = filepath.Join(path.Dir(absURL.Path), parsed.Path)
+			absURL.Path = path.Join(path.Dir(absURL.Path), parsed.Path)
 			ref.absURL = &absURL
 		}
 


### PR DESCRIPTION
Fix the `topaz templates install <template-name>` implementation on Windows, which fails with 

```
topaz templates install todo
invalid character '<' looking for beginning of value
```
