### PR TITLE
chore/golang 1.27.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,7 @@ permissions:
 env:
   PRE_RELEASE: ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
   GH_TOKEN: ${{ github.token }}
-  GOEXPERIMENT: "jsonv2"
-  GO_RELEASER_VER: "v2.17.1"
+  GO_RELEASER_VER: "v2.18.0"
   GO_LANGCI_LINT_VER: "v2.13.2"
   SYFT_VER: "v1.13.0"
 

--- a/.goreleaser-test.yml
+++ b/.goreleaser-test.yml
@@ -110,12 +110,13 @@ dockers_v2:
 
     sbom: false # Attestation is not supported for the docker driver.
 
-    retry:
-      attempts: 10
-      delay: 10s
-      max_delay: 2m
-
     extra_files:
     annotations:
     build_args:
     flags:
+
+retry:
+  # https://goreleaser.com/customization/general/retry/
+  attempts: 10
+  delay: 10s
+  max_delay: 5m

--- a/.goreleaser-test.yml
+++ b/.goreleaser-test.yml
@@ -4,7 +4,6 @@ project_name: topaz
 
 env:
   # https://goreleaser.com/customization/env/
-  - GOEXPERIMENT=jsonv2
   - REGISTRY=ghcr.io
   - ORG=aserto-dev
   - REPO=topaz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -218,15 +218,16 @@ dockers_v2:
 
     sbom: false # Attestation is not supported for the docker driver.
 
-    retry:
-      attempts: 10
-      delay: 10s
-      max_delay: 2m
-
     extra_files:
     annotations:
     build_args:
     flags:
+
+retry:
+  # https://goreleaser.com/customization/general/retry/
+  attempts: 10
+  delay: 10s
+  max_delay: 5m
 
 sboms:
   # https://goreleaser.com/customization/sbom/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,6 @@ project_name: topaz
 
 env:
   # https://goreleaser.com/customization/env/
-  - GOEXPERIMENT=jsonv2
   - REGISTRY=ghcr.io
   - ORG=aserto-dev
   - REPO=topaz

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,21 +4,16 @@
     "-count=1"
   ],
   "go.testEnvVars": {
-    "GOEXPERIMENT": "jsonv2",
     "TESTCONTAINERS_RYUK_DISABLED": "true"
   },
-  "go.buildTags": "jsonv2",
+  "go.buildTags": "",
   "go.delveConfig": {
-    "debugAdapter": "dlv-dap",
-    "env": {
-      "GOEXPERIMENT": "jsonv2"
-    }
+    "debugAdapter": "dlv-dap"
   },
   "go.useLanguageServer": true,
   "go.languageServerFlags": [],
   "gopls": {
     "buildFlags": [
-      "-tags=jsonv2"
     ],
     "formatting.gofumpt": true
   },

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aserto-dev/topaz
 
 go 1.26.3
 
-toolchain go1.26.7
+toolchain go1.27.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
@@ -59,7 +59,7 @@ require (
 	go.etcd.io/bbolt v1.5.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260825221802-da73d73af1c5
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260831171406-18b4a7587f8a
 	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -102,7 +102,7 @@ require (
 	github.com/gonvenience/term v1.0.5 // indirect
 	github.com/gonvenience/text v1.0.10 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
@@ -188,7 +188,7 @@ require (
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260825221802-da73d73af1c5 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260831171406-18b4a7587f8a // indirect
 	gopkg.in/ini.v1 v1.67.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDa
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBHOYlCT25+YmGpJ32dZPi75pGEUpj4=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.4 h1:9ZJYjPEJpcleIKcqysXOo14NLQYwu23fzmKRFpIjPjc=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.4/go.mod h1:0xydIeg2omQ9DH6zYMP24Kk57793rnLUvP8fwdbFvz8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 h1:/Tnpcb2E0Pz/tN9s3bfEY2Q8ePCEX9iuS+cneUwncnw=
@@ -558,10 +558,10 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20230202175211-008b39050e57 h1:vArvWooPH749rNHpBGgVl+U9B9dATjiEhJzcWGlovNs=
 google.golang.org/genproto v0.0.0-20230202175211-008b39050e57/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
-google.golang.org/genproto/googleapis/api v0.0.0-20260825221802-da73d73af1c5 h1:izFU9hz7aeLI/Mi1J0991ae+xcwRLr7hTqWnB/9aIIU=
-google.golang.org/genproto/googleapis/api v0.0.0-20260825221802-da73d73af1c5/go.mod h1:3LhxRw4YYkf+ylAfgaY9JlVLFKhokkCV8duhLLe7+t0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260825221802-da73d73af1c5 h1:1VUiZAXyC+zmiFYi+WLtBzr68Cj8wOofHjjrA/kkizc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260825221802-da73d73af1c5/go.mod h1:DjtHYE8FKJLivXcBEjGwndXfIC23G0VpXiXKqG179uA=
+google.golang.org/genproto/googleapis/api v0.0.0-20260831171406-18b4a7587f8a h1:i3TAXhpKc7TUP1VAPiBBrv45kamjoizCC3rOC0cAbOs=
+google.golang.org/genproto/googleapis/api v0.0.0-20260831171406-18b4a7587f8a/go.mod h1:CvYJHpbzPlT0fb/PsgtAamdwru/GVxUsomFdXTpOTI8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260831171406-18b4a7587f8a h1:3Dnd1cDaZlB68lziofO+bJXpjOy8UfRv8Unt+yH8tQ4=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260831171406-18b4a7587f8a/go.mod h1:DjtHYE8FKJLivXcBEjGwndXfIC23G0VpXiXKqG179uA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/makefile
+++ b/makefile
@@ -22,18 +22,17 @@ EXT_DIR            := ${PWD}/.ext
 EXT_BIN_DIR        := ${EXT_DIR}/bin
 EXT_TMP_DIR        := ${EXT_DIR}/tmp
 
-GO_VER             := 1.26
+GO_VER             := 1.27
 SVU_VER            := 3.4.1
 GOTESTSUM_VER      := 1.13.0
 GOLANGCI-LINT_VER  := 2.13.2
-GORELEASER_VER     := 2.17.1
+GORELEASER_VER     := 2.18.0
 SYFT_VER           := 1.13.0
 
 RELEASE_TAG        := $$(${EXT_BIN_DIR}/svu current)
 
 .DEFAULT_GOAL      := build
 
-export GOEXPERIMENT=jsonv2
 export TESTCONTAINERS_RYUK_DISABLED=$(shell docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null | grep -q ".colima" && echo "true" || echo "false")
 
 .PHONY: deps

--- a/topazd/signals/signal_posix.go
+++ b/topazd/signals/signal_posix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2017 The Kubernetes Authors.


### PR DESCRIPTION
Update to golang 1.27.1
Remove GOEXPERIMENT: "jsonv2", as this is enabled by default in 1.27
Update goreleaser to v2.18.0 (build with golang 1.27)